### PR TITLE
docs: summarize current image export implementation and flow

### DIFF
--- a/docs/image-export-current-state.md
+++ b/docs/image-export-current-state.md
@@ -1,0 +1,6 @@
+# 画像出力（保存）機能の現状メモ
+
+- 実装本体は `src/screens/TodayScreen.tsx` にあり、`react-native-view-shot` で非表示領域をキャプチャし、`expo-media-library` で写真ライブラリへ保存している。
+- UIの導線は `CalendarScreen` で日付セルをタップして `Today` 画面へ遷移し、`Today` 画面内の「画像として保存」ボタンで実行される。
+- 保存対象は画面表示用UIではなく、`hiddenRenderer` 内の `ViewShot` コンテナ。
+- 現在の出力サイズは `exportContainer.width = 720`（固定幅）で、フォーマットは JPEG。


### PR DESCRIPTION
### Motivation
- 画像出力を `1080×1080` の正方形テンプレ背景PNG＋UIオーバーレイ方式へ移行する前に、現行の出力実装・導線・仕様を開発チームで共有するための基礎ドキュメントを追加しました。

### Description
- 追加した `docs/image-export-current-state.md` に現状メモを記載し、出力本体が `src/screens/TodayScreen.tsx`（`react-native-view-shot` で非表示領域をキャプチャ → `expo-media-library` で保存）であること、遷移元が `src/screens/CalendarScreen.tsx` であること、現在は JPEG（`exportContainer.width = 720`）で出力されていることを明記し、変更対象の最小ファイル群としてまずは `src/screens/TodayScreen.tsx` と背景テンプレ資産（例: `assets/*.png`）を提案しました。

### Testing
- 実行した型チェック `npx tsc --noEmit` はリポジトリの既存 `tsconfig` 設定（`bundler` と `module` の組合せ）に起因するエラーで失敗しており、本ドキュメント追加とは無関係な問題です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f0d38de3c8323af298c111950884f)