### PR TITLE
Fix missing February/March age labels in preterm calendar view

### DIFF
--- a/__tests__/age.dateUtils.test.ts
+++ b/__tests__/age.dateUtils.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { calculateAgeInfo } from "../src/utils/dateUtils";
+import { buildCalendarMonthView, calculateAgeInfo } from "../src/utils/dateUtils";
 
 const hasNegativeSign = (value: string) => value.includes("-");
 
@@ -75,5 +75,32 @@ assert.equal(onDue.corrected.formatted, "0ヶ月0日");
 assert.equal(onDue.gestational.visible, false);
 
 assert.equal(shouldShowDaysText(false, onDue.daysSinceBirth), null);
+
+
+const settings = {
+  ageFormat: "md" as const,
+  showCorrectedUntilMonths: null,
+  showDaysSinceBirth: false,
+  lastViewedMonth: null,
+};
+
+const februaryView = buildCalendarMonthView({
+  anchorDate: new Date(2025, 1, 1),
+  settings,
+  birthDate: "2025-01-01",
+  dueDate: "2025-03-01",
+});
+const februaryFirst = februaryView.days.find((day) => day.date === "2025-02-01");
+assert.equal(februaryFirst?.calendarAgeLabel?.chronological, "暦 1ヶ月");
+
+const marchView = buildCalendarMonthView({
+  anchorDate: new Date(2025, 2, 1),
+  settings,
+  birthDate: "2025-01-01",
+  dueDate: "2025-03-01",
+});
+const marchFirst = marchView.days.find((day) => day.date === "2025-03-01");
+assert.equal(marchFirst?.calendarAgeLabel?.chronological, "暦 2ヶ月");
+assert.equal(marchFirst?.calendarAgeLabel?.corrected, "修正 0ヶ月");
 
 console.log("age.dateUtils tests passed");

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -266,7 +266,6 @@ export const buildCalendarMonthView = ({
   const days: CalendarDay[] = [];
   const hasValidBirthDate = Boolean(birthDate) && isIsoDateString(birthDate);
   const normalizedDueDate = dueDate && isIsoDateString(dueDate) ? dueDate : null;
-  let previousAgeInfo: AgeInfo | null = null;
 
   for (let offset = 0; offset < cellCount; offset += 1) {
     const date = new Date(startDate);
@@ -289,26 +288,17 @@ export const buildCalendarMonthView = ({
 
     const isBirthDay = Boolean(birthDate && iso === birthDate);
     const chronologicalChanged =
-      Boolean(ageInfo && previousAgeInfo &&
-      totalMonthsFromParts(ageInfo.chronological) === totalMonthsFromParts(previousAgeInfo.chronological) + 1) || isBirthDay;
+      Boolean(ageInfo && ageInfo.chronological.days === 0) || isBirthDay;
 
     const correctedVisible = Boolean(ageInfo?.corrected.visible && ageInfo.corrected.formatted);
-    const previousCorrectedVisible = Boolean(
-      previousAgeInfo?.corrected.visible && previousAgeInfo.corrected.formatted
-    );
     const correctedChanged =
       correctedVisible &&
-      previousCorrectedVisible &&
-      totalMonthsFromParts(ageInfo!.corrected) === totalMonthsFromParts(previousAgeInfo!.corrected) + 1;
+      ageInfo!.corrected.days === 0;
 
     const gestationalVisible = Boolean(ageInfo?.gestational.visible && ageInfo.gestational.formatted);
-    const previousGestationalVisible = Boolean(
-      previousAgeInfo?.gestational.visible && previousAgeInfo.gestational.formatted
-    );
     const gestationalChanged =
       gestationalVisible &&
-      previousGestationalVisible &&
-      ageInfo!.gestational.weeks === previousAgeInfo!.gestational.weeks + 1;
+      ageInfo!.gestational.days === 0;
 
     let calendarAgeLabel =
       ageInfo && (chronologicalChanged || correctedChanged || gestationalChanged)
@@ -339,7 +329,6 @@ export const buildCalendarMonthView = ({
       hasAchievements: (achievementCountsByDay?.[iso] ?? 0) > 0,
     });
 
-    previousAgeInfo = ageInfo;
   }
 
   return {


### PR DESCRIPTION
### Motivation
- The calendar missed month-age labels around due-date mode boundaries because milestone emission relied on comparing the previous cell (+1 month/+1 week), which fails when display mode changes (gestational → corrected). 
- The reported scenario (`birthDate = 2025-01-01`, `dueDate = 2025-03-01`) caused February and March labels to be suppressed.

### Description
- Changed milestone detection in `buildCalendarMonthView` (`src/utils/dateUtils.ts`) to use date-part boundaries by checking `ageInfo.chronological.days === 0`, `ageInfo.corrected.days === 0`, and `ageInfo.gestational.days === 0` instead of comparing to the previous cell. 
- Removed reliance on `previousAgeInfo` / previous-cell visibility for emitting labels to ensure labels appear at natural month/week boundaries even across mode transitions. 
- Added regression checks to `__tests__/age.dateUtils.test.ts` to assert that `2025-02-01` shows `暦 1ヶ月` and `2025-03-01` shows `暦 2ヶ月` plus `修正 0ヶ月`.

### Testing
- Ran the age utils tests with `npm test -- --runInBand __tests__/age.dateUtils.test.ts`, and the test suite passed. 
- The added regression asserts for `buildCalendarMonthView` validate the reported `birthDate=2025-01-01, dueDate=2025-03-01` case and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ff9afc9688323a7e3c23c99d016e4)