### PR TITLE
Add Phase G: UI minimal tests for all 8 screen components (TS-UI-003~…

### DIFF
--- a/__tests__/AchievementListScreen.ui.jest.test.tsx
+++ b/__tests__/AchievementListScreen.ui.jest.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+let mockActiveUser: any = null;
+let mockStore: any = {};
+let mockLoading = false;
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('@/components/AppText', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ children, style }: any) => React.createElement(Text, { style }, children),
+  };
+});
+
+jest.mock('@/components/DatePickerModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/state/AppStateContext', () => ({
+  useActiveUser: () => mockActiveUser,
+}));
+
+jest.mock('@/state/AchievementsContext', () => ({
+  useAchievements: () => ({ loading: mockLoading, store: mockStore }),
+}));
+
+const mockNavigation = { navigate: jest.fn() };
+const mockRoute = { params: {} };
+
+const renderScreen = () => {
+  const AchievementListScreen = require('../src/screens/AchievementListScreen').default;
+  return render(
+    React.createElement(AchievementListScreen, { navigation: mockNavigation, route: mockRoute })
+  );
+};
+
+describe('AchievementListScreen UI (TS-UI-007)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStore = {};
+    mockLoading = false;
+    mockActiveUser = {
+      id: 'u1',
+      name: 'テストちゃん',
+      birthDate: '2024-01-01',
+      dueDate: null,
+      settings: {
+        showCorrectedUntilMonths: 24,
+        ageFormat: 'ymd',
+        showDaysSinceBirth: true,
+        lastViewedMonth: null,
+      },
+    };
+  });
+
+  test('記録なし: まだ記録がありませんを表示', () => {
+    const { queryByText } = renderScreen();
+    expect(queryByText('まだ記録がありません')).not.toBeNull();
+  });
+
+  test('ローディング中: 読み込み中...を表示', () => {
+    mockLoading = true;
+    const { queryByText } = renderScreen();
+    expect(queryByText('読み込み中...')).not.toBeNull();
+  });
+
+  test('記録あり: 記録タイトルを表示', () => {
+    mockStore = {
+      '2024-06-01': [
+        {
+          id: 'r1',
+          date: '2024-06-01',
+          title: '初めてのつかまり立ち',
+          memo: '',
+          createdAt: '2024-06-01T00:00:00.000Z',
+          updatedAt: '2024-06-01T00:00:00.000Z',
+        },
+      ],
+    };
+    const { queryByText } = renderScreen();
+    expect(queryByText('初めてのつかまり立ち')).not.toBeNull();
+  });
+
+  test('user=null: プロフィール未設定のヘッダーを表示', () => {
+    mockActiveUser = null;
+    const { queryByText } = renderScreen();
+    expect(queryByText('プロフィール未設定 記録一覧')).not.toBeNull();
+  });
+
+  test('FABボタン（＋記録）が描画される', () => {
+    const { queryByText } = renderScreen();
+    expect(queryByText('＋記録')).not.toBeNull();
+  });
+});

--- a/__tests__/CalendarScreen.ui.jest.test.tsx
+++ b/__tests__/CalendarScreen.ui.jest.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+let mockActiveUser: any = null;
+
+const mockLoadMonth = jest.fn().mockResolvedValue(undefined);
+const mockUpdateUser = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('@/state/AppStateContext', () => ({
+  useActiveUser: () => mockActiveUser,
+  useAppState: () => ({ updateUser: mockUpdateUser }),
+}));
+
+jest.mock('@/state/AchievementsContext', () => ({
+  useAchievements: () => ({ monthCounts: {}, loadMonth: mockLoadMonth }),
+}));
+
+jest.mock('@/state/DateViewContext', () => ({
+  useDateViewContext: () => ({ selectDateFromCalendar: jest.fn() }),
+}));
+
+jest.mock('@/components/CalendarGrid', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/CalendarDecorations', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/DatePickerModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/MonthHeader', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockNavigation = { push: jest.fn() };
+const mockRoute = { params: {} };
+
+describe('CalendarScreen UI (TS-UI-003)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('user=null: プロフィール未設定プレースホルダを表示', async () => {
+    mockActiveUser = null;
+    const CalendarScreen = require('../src/screens/CalendarScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(CalendarScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    expect(tree.toJSON()).not.toBeNull();
+    // ヘッダーに未設定文言が含まれる
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('プロフィール未設定');
+  });
+
+  test('user あり・birthDate あり: 名前と年齢情報を表示しloadMonthを呼ぶ', async () => {
+    mockActiveUser = {
+      id: 'u1',
+      name: 'テストちゃん',
+      birthDate: '2024-06-01',
+      dueDate: null,
+      settings: {
+        showCorrectedUntilMonths: 24,
+        ageFormat: 'ymd' as const,
+        showDaysSinceBirth: true,
+        lastViewedMonth: null,
+      },
+    };
+    const CalendarScreen = require('../src/screens/CalendarScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(CalendarScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    expect(tree.toJSON()).not.toBeNull();
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('テストちゃん');
+    expect(mockLoadMonth).toHaveBeenCalled();
+  });
+
+  test('user あり・birthDate なし: 年齢情報なしプレースホルダを表示', async () => {
+    mockActiveUser = {
+      id: 'u1',
+      name: '名前ちゃん',
+      birthDate: '',
+      dueDate: null,
+      settings: {
+        showCorrectedUntilMonths: 24,
+        ageFormat: 'md' as const,
+        showDaysSinceBirth: false,
+        lastViewedMonth: null,
+      },
+    };
+    const CalendarScreen = require('../src/screens/CalendarScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(CalendarScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    expect(tree.toJSON()).not.toBeNull();
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('年齢情報は設定済みのプロフィールで表示されます');
+  });
+
+  test('FABボタン（＋記録）が描画される', async () => {
+    mockActiveUser = null;
+    const CalendarScreen = require('../src/screens/CalendarScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(CalendarScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('＋記録');
+  });
+});

--- a/__tests__/ProfileEditScreen.ui.jest.test.tsx
+++ b/__tests__/ProfileEditScreen.ui.jest.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+let mockAppState: any = { users: [], activeUserId: null };
+const mockAddUser = jest.fn().mockResolvedValue(undefined);
+const mockUpdateUser = jest.fn().mockResolvedValue(undefined);
+const mockDeleteUser = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@/components/AppText', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ children, style }: any) => React.createElement(Text, { style }, children),
+  };
+});
+
+jest.mock('@/components/DatePickerModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/state/AppStateContext', () => ({
+  useAppState: () => ({
+    state: mockAppState,
+    addUser: mockAddUser,
+    updateUser: mockUpdateUser,
+    deleteUser: mockDeleteUser,
+  }),
+}));
+
+const mockNavigation = {
+  goBack: jest.fn(),
+  popToTop: jest.fn(),
+  getParent: jest.fn().mockReturnValue({ setOptions: jest.fn() }),
+};
+
+describe('ProfileEditScreen UI (TS-UI-009)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNavigation.getParent.mockReturnValue({ setOptions: jest.fn() });
+  });
+
+  test('新規プロフィール（profileId なし）: 「新しいこどもを追加」を表示', async () => {
+    mockAppState = { users: [], activeUserId: null };
+    const routeNew = { params: {} };
+    const ProfileEditScreen = require('../src/screens/ProfileEditScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(ProfileEditScreen, { navigation: mockNavigation, route: routeNew })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('新しいこどもを追加');
+  });
+
+  test('既存プロフィール（profileId あり）: 「プロフィールを編集」と削除ボタンを表示', async () => {
+    const existingUser = {
+      id: 'u1',
+      name: 'テストちゃん',
+      birthDate: '2024-01-01',
+      dueDate: null,
+      settings: {
+        showCorrectedUntilMonths: 24,
+        ageFormat: 'ymd' as const,
+        showDaysSinceBirth: true,
+        lastViewedMonth: null,
+      },
+    };
+    mockAppState = { users: [existingUser, { ...existingUser, id: 'u2', name: '別のこ' }], activeUserId: 'u1' };
+    const routeEdit = { params: { profileId: 'u1' } };
+    const ProfileEditScreen = require('../src/screens/ProfileEditScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(ProfileEditScreen, { navigation: mockNavigation, route: routeEdit })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('プロフィールを編集');
+    expect(json).toContain('このプロフィールを削除する');
+  });
+
+  test('フォームに出生日・出産予定日フィールドが表示される', async () => {
+    mockAppState = { users: [], activeUserId: null };
+    const routeNew = { params: {} };
+    const ProfileEditScreen = require('../src/screens/ProfileEditScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(ProfileEditScreen, { navigation: mockNavigation, route: routeNew })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('出生日');
+    expect(json).toContain('出産予定日');
+    expect(json).toContain('保存');
+  });
+
+  test('修正月齢の表示上限オプションが表示される', async () => {
+    mockAppState = { users: [], activeUserId: null };
+    const routeNew = { params: {} };
+    const ProfileEditScreen = require('../src/screens/ProfileEditScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(ProfileEditScreen, { navigation: mockNavigation, route: routeNew })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('24か月');
+    expect(json).toContain('36か月');
+    expect(json).toContain('制限なし');
+  });
+});

--- a/__tests__/ProfileManagerScreen.ui.jest.test.tsx
+++ b/__tests__/ProfileManagerScreen.ui.jest.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+let mockAppState: any = { users: [], activeUserId: null };
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('@/components/AppText', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ children, style }: any) => React.createElement(Text, { style }, children),
+  };
+});
+
+jest.mock('@/state/AppStateContext', () => ({
+  useAppState: () => ({ state: mockAppState }),
+}));
+
+const mockNavigation = {
+  goBack: jest.fn(),
+  navigate: jest.fn(),
+  getParent: jest.fn().mockReturnValue({ setOptions: jest.fn() }),
+};
+const mockRoute = { params: {} };
+
+describe('ProfileManagerScreen UI (TS-UI-010)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNavigation.getParent.mockReturnValue({ setOptions: jest.fn() });
+  });
+
+  test('users なし: ガイドテキストと追加ボタンを表示', async () => {
+    mockAppState = { users: [], activeUserId: null };
+    const ProfileManagerScreen = require('../src/screens/ProfileManagerScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(ProfileManagerScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('新しいこどもを追加');
+    expect(json).toContain('編集したいこどもを選んでください');
+  });
+
+  test('users あり: ユーザーカードを表示', async () => {
+    mockAppState = {
+      users: [
+        {
+          id: 'u1',
+          name: 'テストちゃん',
+          birthDate: '2024-01-01',
+          dueDate: '2024-02-15',
+          settings: {
+            showCorrectedUntilMonths: 24,
+            ageFormat: 'ymd',
+            showDaysSinceBirth: true,
+            lastViewedMonth: null,
+          },
+        },
+      ],
+      activeUserId: 'u1',
+    };
+    const ProfileManagerScreen = require('../src/screens/ProfileManagerScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(ProfileManagerScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('テストちゃん');
+    expect(json).toContain('2024-01-01');
+    expect(json).toContain('編集');
+  });
+
+  test('dueDate なし: なしを表示', async () => {
+    mockAppState = {
+      users: [
+        {
+          id: 'u1',
+          name: 'テストちゃん',
+          birthDate: '2024-01-01',
+          dueDate: null,
+          settings: {
+            showCorrectedUntilMonths: 24,
+            ageFormat: 'ymd',
+            showDaysSinceBirth: true,
+            lastViewedMonth: null,
+          },
+        },
+      ],
+      activeUserId: 'u1',
+    };
+    const ProfileManagerScreen = require('../src/screens/ProfileManagerScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(ProfileManagerScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('なし');
+  });
+
+  test('複数ユーザー: 全ユーザーのカードを表示', async () => {
+    mockAppState = {
+      users: [
+        {
+          id: 'u1',
+          name: 'ちゃん1',
+          birthDate: '2024-01-01',
+          dueDate: null,
+          settings: { showCorrectedUntilMonths: 24, ageFormat: 'ymd', showDaysSinceBirth: true, lastViewedMonth: null },
+        },
+        {
+          id: 'u2',
+          name: 'ちゃん2',
+          birthDate: '2023-05-10',
+          dueDate: null,
+          settings: { showCorrectedUntilMonths: 24, ageFormat: 'ymd', showDaysSinceBirth: true, lastViewedMonth: null },
+        },
+      ],
+      activeUserId: 'u1',
+    };
+    const ProfileManagerScreen = require('../src/screens/ProfileManagerScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(ProfileManagerScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('ちゃん1');
+    expect(json).toContain('ちゃん2');
+  });
+});

--- a/__tests__/RecordDetailScreen.ui.jest.test.tsx
+++ b/__tests__/RecordDetailScreen.ui.jest.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+let mockActiveUser: any = null;
+let mockStore: any = {};
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('@/components/AppText', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ children, style }: any) => React.createElement(Text, { style }, children),
+  };
+});
+
+jest.mock('@/state/AppStateContext', () => ({
+  useActiveUser: () => mockActiveUser,
+}));
+
+jest.mock('@/state/AchievementsContext', () => ({
+  useAchievements: () => ({ store: mockStore }),
+}));
+
+jest.mock('@/utils/photo', () => ({
+  ensureFileExistsAsync: jest.fn().mockResolvedValue(null),
+}));
+
+const mockNavigation = {
+  goBack: jest.fn(),
+  navigate: jest.fn(),
+  replace: jest.fn(),
+};
+
+describe('RecordDetailScreen UI (TS-UI-006)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStore = {};
+    mockActiveUser = {
+      id: 'u1',
+      name: 'テストちゃん',
+      birthDate: '2024-01-01',
+      dueDate: null,
+      settings: {
+        showCorrectedUntilMonths: 24,
+        ageFormat: 'ymd',
+        showDaysSinceBirth: true,
+        lastViewedMonth: null,
+      },
+    };
+  });
+
+  test('record=null: 記録が見つかりませんを表示', async () => {
+    mockStore = {};
+    const route = { params: { recordId: 'nonexistent', isoDate: '2024-06-01', from: 'today' } };
+    const RecordDetailScreen = require('../src/screens/RecordDetailScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(RecordDetailScreen, { navigation: mockNavigation, route })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('記録が見つかりません');
+  });
+
+  test('from=list のとき「記録一覧に戻る」ボタンを表示', async () => {
+    mockStore = {};
+    const route = { params: { recordId: 'nonexistent', isoDate: '2024-06-01', from: 'list' } };
+    const RecordDetailScreen = require('../src/screens/RecordDetailScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(RecordDetailScreen, { navigation: mockNavigation, route })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('記録一覧に戻る');
+  });
+
+  test('record あり: 記録詳細を表示', async () => {
+    mockStore = {
+      '2024-06-01': [
+        {
+          id: 'r1',
+          date: '2024-06-01',
+          title: '初めての寝返り',
+          memo: 'とても嬉しかった',
+          createdAt: '2024-06-01T00:00:00.000Z',
+          updatedAt: '2024-06-01T00:00:00.000Z',
+        },
+      ],
+    };
+    const route = { params: { recordId: 'r1', isoDate: '2024-06-01', from: 'today' } };
+    const RecordDetailScreen = require('../src/screens/RecordDetailScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(RecordDetailScreen, { navigation: mockNavigation, route })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('初めての寝返り');
+    expect(json).toContain('とても嬉しかった');
+    expect(json).toContain('編集する');
+  });
+
+  test('user.name なし: ヘッダーが「記録」になる', async () => {
+    mockActiveUser = null;
+    mockStore = {
+      '2024-06-01': [
+        {
+          id: 'r1',
+          date: '2024-06-01',
+          title: 'テスト',
+          memo: '',
+          createdAt: '2024-06-01T00:00:00.000Z',
+          updatedAt: '2024-06-01T00:00:00.000Z',
+        },
+      ],
+    };
+    const route = { params: { recordId: 'r1', isoDate: '2024-06-01', from: 'today' } };
+    const RecordDetailScreen = require('../src/screens/RecordDetailScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(RecordDetailScreen, { navigation: mockNavigation, route })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    // user?.name が null なのでヘッダーは "記録" になる
+    expect(json).toContain('記録');
+  });
+});

--- a/__tests__/RecordInputScreen.ui.jest.test.tsx
+++ b/__tests__/RecordInputScreen.ui.jest.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+let mockActiveUser: any = null;
+let mockStore: any = {};
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('@/components/AppText', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ children, style }: any) => React.createElement(Text, { style }, children),
+  };
+});
+
+jest.mock('@/components/DatePickerModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/state/AppStateContext', () => ({
+  useActiveUser: () => mockActiveUser,
+}));
+
+jest.mock('@/state/AchievementsContext', () => ({
+  useAchievements: () => ({
+    store: mockStore,
+    upsert: jest.fn().mockResolvedValue(undefined),
+    remove: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+// Date インスタンスを安定させる（毎回 new Date() すると useEffect の依存が毎レンダーで変わりOOMになる）
+jest.mock('@/state/DateViewContext', () => {
+  const stableDate = new Date('2024-06-01');
+  return {
+    useDateViewContext: () => ({ selectedDate: stableDate }),
+  };
+});
+
+jest.mock('@/utils/photo', () => ({
+  ensureFileExistsAsync: jest.fn().mockResolvedValue(null),
+  pickAndSavePhotoAsync: jest.fn().mockResolvedValue(null),
+  deleteIfExistsAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockNavigation = {
+  goBack: jest.fn(),
+};
+const mockRoute = { params: {} };
+
+describe('RecordInputScreen UI (TS-UI-005)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStore = {};
+  });
+
+  test('user=null: プロフィールを作成してくださいを表示', async () => {
+    mockActiveUser = null;
+    const RecordInputScreen = require('../src/screens/RecordInputScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(RecordInputScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('プロフィールを作成してください');
+  });
+
+  test('新規記録モード: フォームと保存ボタンを表示', async () => {
+    mockActiveUser = {
+      id: 'u1',
+      name: 'テストちゃん',
+      birthDate: '2024-01-01',
+      dueDate: null,
+      settings: {
+        showCorrectedUntilMonths: 24,
+        ageFormat: 'ymd',
+        showDaysSinceBirth: true,
+        lastViewedMonth: null,
+      },
+    };
+    mockStore = {};
+    const RecordInputScreen = require('../src/screens/RecordInputScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(RecordInputScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('記録する');
+    expect(json).toContain('保存');
+    // 削除ボタンは表示されない
+    expect(json).not.toContain('この記録を削除');
+  });
+
+  test('編集モード: 既存レコードがあれば削除ボタンを表示', async () => {
+    mockActiveUser = {
+      id: 'u1',
+      name: 'テストちゃん',
+      birthDate: '2024-01-01',
+      dueDate: null,
+      settings: {
+        showCorrectedUntilMonths: 24,
+        ageFormat: 'ymd',
+        showDaysSinceBirth: true,
+        lastViewedMonth: null,
+      },
+    };
+    mockStore = {
+      '2024-06-01': [
+        {
+          id: 'r1',
+          date: '2024-06-01',
+          title: 'テスト記録',
+          memo: '',
+          createdAt: '2024-06-01T00:00:00.000Z',
+          updatedAt: '2024-06-01T00:00:00.000Z',
+        },
+      ],
+    };
+    const editRoute = { params: { recordId: 'r1', isoDate: '2024-06-01', from: 'today' } };
+    const RecordInputScreen = require('../src/screens/RecordInputScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(RecordInputScreen, { navigation: mockNavigation, route: editRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('この記録を削除');
+    // タイトルが初期値として入っていること
+    expect(json).toContain('テスト記録');
+  });
+});

--- a/__tests__/SettingsScreen.ui.jest.test.tsx
+++ b/__tests__/SettingsScreen.ui.jest.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+const mockSetActiveUser = jest.fn().mockResolvedValue(undefined);
+let mockAppState: any = { users: [], activeUserId: null };
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('@/components/AppText', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ children, style }: any) => React.createElement(Text, { style }, children),
+  };
+});
+
+jest.mock('@/state/AppStateContext', () => ({
+  useAppState: () => ({ state: mockAppState, setActiveUser: mockSetActiveUser }),
+}));
+
+const mockNavigation = { navigate: jest.fn() };
+const mockRoute = { params: {} };
+
+describe('SettingsScreen UI (TS-UI-008)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('users なし: ベビーを選択セクションを表示', async () => {
+    mockAppState = { users: [], activeUserId: null };
+    const SettingsScreen = require('../src/screens/SettingsScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(SettingsScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('ベビーを選択');
+  });
+
+  test('users あり: ユーザー名を表示', async () => {
+    mockAppState = {
+      users: [
+        {
+          id: 'u1',
+          name: 'テストちゃん',
+          birthDate: '2024-01-01',
+          dueDate: null,
+          settings: {
+            showCorrectedUntilMonths: 24,
+            ageFormat: 'ymd',
+            showDaysSinceBirth: true,
+            lastViewedMonth: null,
+          },
+        },
+      ],
+      activeUserId: 'u1',
+    };
+    const SettingsScreen = require('../src/screens/SettingsScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(SettingsScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('テストちゃん');
+    expect(json).toContain('2024-01-01');
+  });
+
+  test('アクティブユーザーに✓マークが表示される', async () => {
+    mockAppState = {
+      users: [
+        {
+          id: 'u1',
+          name: 'テストちゃん',
+          birthDate: '2024-01-01',
+          dueDate: null,
+          settings: {
+            showCorrectedUntilMonths: 24,
+            ageFormat: 'ymd',
+            showDaysSinceBirth: true,
+            lastViewedMonth: null,
+          },
+        },
+      ],
+      activeUserId: 'u1',
+    };
+    const SettingsScreen = require('../src/screens/SettingsScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(SettingsScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('✓');
+  });
+
+  test('サポートメニューが表示される', async () => {
+    mockAppState = { users: [], activeUserId: null };
+    const SettingsScreen = require('../src/screens/SettingsScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(SettingsScreen, { navigation: mockNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('このアプリについて');
+    expect(json).toContain('プライバシーポリシー');
+    expect(json).toContain('利用規約');
+  });
+});

--- a/__tests__/TodayScreen.ui.jest.test.tsx
+++ b/__tests__/TodayScreen.ui.jest.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+let mockActiveUser: any = null;
+let mockByDay: any = {};
+let mockAchievementsLoading = false;
+
+jest.mock('expo-media-library', () => ({
+  requestPermissionsAsync: jest.fn().mockResolvedValue({ granted: true }),
+  saveToLibraryAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('react-native-view-shot', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const ViewShot = React.forwardRef((_props: any, _ref: any) => React.createElement(View));
+  return { __esModule: true, default: ViewShot };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('@/state/AppStateContext', () => ({
+  useActiveUser: () => mockActiveUser,
+}));
+
+jest.mock('@/state/AchievementsContext', () => ({
+  useAchievements: () => ({ byDay: mockByDay, loading: mockAchievementsLoading }),
+}));
+
+jest.mock('@/state/DateViewContext', () => ({
+  useDateViewContext: () => ({
+    selectedDate: new Date('2024-06-01'),
+    selectDateFromCalendar: jest.fn(),
+  }),
+}));
+
+jest.mock('@/utils/photo', () => ({
+  ensureFileExistsAsync: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/components/AppText', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ children, style }: any) => React.createElement(Text, { style }, children),
+  };
+});
+
+const mockStackNavigation = {
+  popToTop: jest.fn(),
+  getParent: jest.fn().mockReturnValue({ setOptions: jest.fn() }),
+};
+const mockRoute = { params: { isoDate: '2024-06-01' } };
+
+describe('TodayScreen UI (TS-UI-004)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockByDay = {};
+    mockAchievementsLoading = false;
+    mockStackNavigation.getParent.mockReturnValue({ setOptions: jest.fn() });
+  });
+
+  test('user=null: プロフィールを作成してくださいを表示', async () => {
+    mockActiveUser = null;
+    const TodayScreen = require('../src/screens/TodayScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(TodayScreen, { navigation: mockStackNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('プロフィールを作成してください');
+  });
+
+  test('user あり・birthDate なし: 生年月日が未設定ですを表示', async () => {
+    mockActiveUser = {
+      id: 'u1',
+      name: 'テストちゃん',
+      birthDate: null,
+      dueDate: null,
+      settings: {
+        showCorrectedUntilMonths: 24,
+        ageFormat: 'ymd',
+        showDaysSinceBirth: true,
+        lastViewedMonth: null,
+      },
+    };
+    const TodayScreen = require('../src/screens/TodayScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(TodayScreen, { navigation: mockStackNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('生年月日が未設定です');
+  });
+
+  test('user あり・birthDate あり・記録なし: 今日の記録セクションを表示', async () => {
+    mockActiveUser = {
+      id: 'u1',
+      name: 'テストちゃん',
+      birthDate: '2024-01-01',
+      dueDate: null,
+      settings: {
+        showCorrectedUntilMonths: 24,
+        ageFormat: 'ymd',
+        showDaysSinceBirth: true,
+        lastViewedMonth: null,
+      },
+    };
+    mockByDay = {};
+    const TodayScreen = require('../src/screens/TodayScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(TodayScreen, { navigation: mockStackNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('今日の記録');
+    expect(json).toContain('気づいたことがあれば記録しよう');
+  });
+
+  test('記録あり: 記録カードを表示', async () => {
+    mockActiveUser = {
+      id: 'u1',
+      name: 'テストちゃん',
+      birthDate: '2024-01-01',
+      dueDate: null,
+      settings: {
+        showCorrectedUntilMonths: 24,
+        ageFormat: 'ymd',
+        showDaysSinceBirth: false,
+        lastViewedMonth: null,
+      },
+    };
+    mockByDay = {
+      '2024-06-01': [
+        {
+          id: 'r1',
+          date: '2024-06-01',
+          title: '初めての笑顔',
+          memo: '',
+          createdAt: '2024-06-01T00:00:00.000Z',
+          updatedAt: '2024-06-01T00:00:00.000Z',
+        },
+      ],
+    };
+    const TodayScreen = require('../src/screens/TodayScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(TodayScreen, { navigation: mockStackNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('初めての笑顔');
+  });
+
+  test('ローディング中: 読み込み中...を表示', async () => {
+    mockActiveUser = {
+      id: 'u1',
+      name: 'テストちゃん',
+      birthDate: '2024-01-01',
+      dueDate: null,
+      settings: {
+        showCorrectedUntilMonths: 24,
+        ageFormat: 'ymd',
+        showDaysSinceBirth: true,
+        lastViewedMonth: null,
+      },
+    };
+    mockByDay = {};
+    mockAchievementsLoading = true;
+    const TodayScreen = require('../src/screens/TodayScreen').default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(TodayScreen, { navigation: mockStackNavigation, route: mockRoute })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('読み込み中...');
+  });
+});

--- a/docs/testing/test-matrix.md
+++ b/docs/testing/test-matrix.md
@@ -24,6 +24,14 @@
 | `src/screens/AboutScreen.tsx` | `AboutScreen (default)` | `__tests__/app.navigation.ui.jest.test.tsx` | ✅ |
 | `src/screens/TermsScreen.tsx` | `TermsScreen (default)` | `__tests__/app.navigation.ui.jest.test.tsx` | ✅ |
 | `src/screens/PrivacyPolicyScreen.tsx` | `PrivacyPolicyScreen (default)` | `__tests__/app.navigation.ui.jest.test.tsx` | ✅ |
+| `src/screens/CalendarScreen.tsx` | `CalendarScreen (default)` | `__tests__/CalendarScreen.ui.jest.test.tsx` | ✅ |
+| `src/screens/TodayScreen.tsx` | `TodayScreen (default)` | `__tests__/TodayScreen.ui.jest.test.tsx` | ✅ |
+| `src/screens/RecordInputScreen.tsx` | `RecordInputScreen (default)` | `__tests__/RecordInputScreen.ui.jest.test.tsx` | ✅ |
+| `src/screens/RecordDetailScreen.tsx` | `RecordDetailScreen (default)` | `__tests__/RecordDetailScreen.ui.jest.test.tsx` | ✅ |
+| `src/screens/AchievementListScreen.tsx` | `AchievementListScreen (default)` | `__tests__/AchievementListScreen.ui.jest.test.tsx` | ✅ |
+| `src/screens/SettingsScreen.tsx` | `SettingsScreen (default)` | `__tests__/SettingsScreen.ui.jest.test.tsx` | ✅ |
+| `src/screens/ProfileEditScreen.tsx` | `ProfileEditScreen (default)` | `__tests__/ProfileEditScreen.ui.jest.test.tsx` | ✅ |
+| `src/screens/ProfileManagerScreen.tsx` | `ProfileManagerScreen (default)` | `__tests__/ProfileManagerScreen.ui.jest.test.tsx` | ✅ |
 
 ### 非関数 export（補助）
 - 型・interface export: `src/models/dataModels.ts`, `src/navigation/types.ts`, `src/state/*` など。
@@ -55,6 +63,14 @@
 | TS-CONTENT-001 | 法務文面・メタデータの公開定数 | ✅ | — | — | 対象外 | `__tests__/models.types.content.jest.test.ts` |
 | TS-MODEL-001 | 既定ユーザー設定定数（types/models） | ✅ | — | — | 対象外 | `__tests__/models.types.content.jest.test.ts` |
 | TS-ZERO-002 | type専用/ブリッジモジュールは coverage 対象から除外 | — | — | — | 対象外 | `jest.config.js`, `package.json` (`typecheck`) |
+| TS-UI-003 | CalendarScreen の最小UI検証 | — | — | ✅ | 対象外 | `__tests__/CalendarScreen.ui.jest.test.tsx` |
+| TS-UI-004 | TodayScreen の最小UI検証 | — | — | ✅ | 対象外 | `__tests__/TodayScreen.ui.jest.test.tsx` |
+| TS-UI-005 | RecordInputScreen の最小UI検証 | — | — | ✅ | 対象外 | `__tests__/RecordInputScreen.ui.jest.test.tsx` |
+| TS-UI-006 | RecordDetailScreen の最小UI検証 | — | — | ✅ | 対象外 | `__tests__/RecordDetailScreen.ui.jest.test.tsx` |
+| TS-UI-007 | AchievementListScreen の最小UI検証 | — | — | ✅ | 対象外 | `__tests__/AchievementListScreen.ui.jest.test.tsx` |
+| TS-UI-008 | SettingsScreen の最小UI検証 | — | — | ✅ | 対象外 | `__tests__/SettingsScreen.ui.jest.test.tsx` |
+| TS-UI-009 | ProfileEditScreen の最小UI検証 | — | — | ✅ | 対象外 | `__tests__/ProfileEditScreen.ui.jest.test.tsx` |
+| TS-UI-010 | ProfileManagerScreen の最小UI検証 | — | — | ✅ | 対象外 | `__tests__/ProfileManagerScreen.ui.jest.test.tsx` |
 
 ## 現状サマリ
 - 旧 ⛔ 対象（`photo.ts` / `AppStateContext` / `AchievementsContext` / `DateViewContext`）を Jest テスト追加で ✅ 化。
@@ -67,3 +83,5 @@
 - Phase F+ (targeted) で `DayCell` / `AchievementsContext` / `AppStateContext` / `storage` / `dateUtils` の未踏候補を狙い撃ち検証。
 
 - Final targeted run: `AchievementsContext` の month 集約分岐（新規月/既存月）を追加検証。
+
+- Phase G で未テスト画面コンポーネント 8 画面に UI 最小テストを追加（TS-UI-003〜010）。

--- a/docs/testing/test-spec.md
+++ b/docs/testing/test-spec.md
@@ -253,3 +253,92 @@
 
 
 - Phase F で対象ファイルの残分岐を列挙し、実装挙動に基づく最小ケースを追加。
+
+## TS-UI-003 CalendarScreen の最小UI検証
+- 対象: `CalendarScreen`
+- 実装根拠: `src/screens/CalendarScreen.tsx`
+- 実装上の挙動:
+  1. `user=null` のとき、ヘッダーに「プロフィール未設定」を表示する。
+  2. `user` があり `birthDate` が有効なとき、名前と年齢情報を表示し `loadMonth` を呼ぶ。
+  3. `user` があり `birthDate` が空のとき、「年齢情報は設定済みのプロフィールで表示されます」を表示する。
+  4. FABボタン「＋記録」が常に描画される。
+- テスト:
+  - `__tests__/CalendarScreen.ui.jest.test.tsx`
+
+## TS-UI-004 TodayScreen の最小UI検証
+- 対象: `TodayScreen`
+- 実装根拠: `src/screens/TodayScreen.tsx`
+- 実装上の挙動:
+  1. `user=null` のとき「プロフィールを作成してください」を表示する。
+  2. `user` があり `birthDate=null` のとき「生年月日が未設定です」を表示する。
+  3. `user` があり `birthDate` 有効・記録なしのとき「今日の記録」と「気づいたことがあれば記録しよう」を表示する。
+  4. 記録があるとき、記録タイトルのカードを表示する。
+  5. `achievementsLoading=true` のとき「読み込み中...」を表示する。
+- テスト:
+  - `__tests__/TodayScreen.ui.jest.test.tsx`
+
+## TS-UI-005 RecordInputScreen の最小UI検証
+- 対象: `RecordInputScreen`
+- 実装根拠: `src/screens/RecordInputScreen.tsx`
+- 実装上の挙動:
+  1. `user=null` のとき「プロフィールを作成してください」を表示する。
+  2. 新規記録モード（`recordId` なし）のとき、フォームと「記録する」「保存」を表示し削除ボタンは表示しない。
+  3. 編集モード（`recordId` あり・store に該当レコードあり）のとき「この記録を削除」ボタンを表示する。
+- テスト:
+  - `__tests__/RecordInputScreen.ui.jest.test.tsx`
+
+## TS-UI-006 RecordDetailScreen の最小UI検証
+- 対象: `RecordDetailScreen`
+- 実装根拠: `src/screens/RecordDetailScreen.tsx`
+- 実装上の挙動:
+  1. store に該当レコードがないとき「記録が見つかりません」を表示する。
+  2. `from="list"` のとき「記録一覧に戻る」ボタンを表示する。
+  3. レコードが見つかったとき、タイトル・メモ・「編集する」ボタンを表示する。
+  4. `user=null` のとき、ヘッダーが「記録」になる。
+- テスト:
+  - `__tests__/RecordDetailScreen.ui.jest.test.tsx`
+
+## TS-UI-007 AchievementListScreen の最小UI検証
+- 対象: `AchievementListScreen`
+- 実装根拠: `src/screens/AchievementListScreen.tsx`
+- 実装上の挙動:
+  1. store が空のとき「まだ記録がありません」を表示する。
+  2. `loading=true` のとき「読み込み中...」を表示する。
+  3. store に記録があるとき、記録タイトルを表示する。
+  4. `user=null` のとき「プロフィール未設定 記録一覧」ヘッダーを表示する。
+  5. FABボタン「＋記録」が常に描画される。
+- テスト:
+  - `__tests__/AchievementListScreen.ui.jest.test.tsx`
+
+## TS-UI-008 SettingsScreen の最小UI検証
+- 対象: `SettingsScreen`
+- 実装根拠: `src/screens/SettingsScreen.tsx`
+- 実装上の挙動:
+  1. 「ベビーを選択」セクションが表示される。
+  2. ユーザーがある場合、名前と生年月日を表示する。
+  3. アクティブユーザーに「✓」マークが表示される。
+  4. サポートメニュー（このアプリについて・プライバシーポリシー・利用規約）が表示される。
+- テスト:
+  - `__tests__/SettingsScreen.ui.jest.test.tsx`
+
+## TS-UI-009 ProfileEditScreen の最小UI検証
+- 対象: `ProfileEditScreen`
+- 実装根拠: `src/screens/ProfileEditScreen.tsx`
+- 実装上の挙動:
+  1. `profileId` なしのとき「新しいこどもを追加」をヘッダーに表示する。
+  2. `profileId` ありのとき「プロフィールを編集」と「このプロフィールを削除する」ボタンを表示する。
+  3. 出生日・出産予定日フィールドと「保存」ボタンが表示される。
+  4. 修正月齢の表示上限オプション（24か月・36か月・制限なし）が表示される。
+- テスト:
+  - `__tests__/ProfileEditScreen.ui.jest.test.tsx`
+
+## TS-UI-010 ProfileManagerScreen の最小UI検証
+- 対象: `ProfileManagerScreen`
+- 実装根拠: `src/screens/ProfileManagerScreen.tsx`
+- 実装上の挙動:
+  1. ユーザーなしのとき、ガイドテキストと「新しいこどもを追加」ボタンが表示される。
+  2. ユーザーがある場合、名前・誕生日カードと「編集」ボタンを表示する。
+  3. `dueDate=null` のとき「なし」と表示する。
+  4. 複数ユーザーがある場合、全員のカードを表示する。
+- テスト:
+  - `__tests__/ProfileManagerScreen.ui.jest.test.tsx`


### PR DESCRIPTION
…010)

- Add CalendarScreen, TodayScreen, RecordInputScreen, RecordDetailScreen, AchievementListScreen, SettingsScreen, ProfileEditScreen, ProfileManagerScreen UI tests (33 tests across 8 suites, all passing)
- Fix RecordInputScreen test: use stable Date instance in DateViewContext mock to prevent useEffect infinite loop / OOM
- Use @testing-library/react-native for AchievementListScreen to avoid FlatList circular reference issue with react-test-renderer
- Update docs/testing/test-spec.md and test-matrix.md with TS-UI-003~010