### PR TITLE
fix: iPad非対応設定に変更 (#81)

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
       "backgroundColor": "#FFFFFF"
     },
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": false
     },
     "android": {
       "adaptiveIcon": {


### PR DESCRIPTION
## Summary
- `app.json` の `ios.supportsTablet` を `true` から `false` に変更
- iPadでの動作を非対応として明示する

## 変更ファイル
- `app.json`: `ios.supportsTablet: false`

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)