### PR TITLE
fix: expo-file-system を dependencies に追加 (#76)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@react-navigation/native-stack": "^7.8.0",
         "babel-preset-expo": "~54.0.10",
         "expo": "~54.0.33",
+        "expo-file-system": "^55.0.11",
         "expo-font": "~14.0.11",
         "expo-image-manipulator": "~14.0.8",
         "expo-image-picker": "~17.0.10",
@@ -34,14 +35,14 @@
         "react-native-worklets": "0.5.1"
       },
       "devDependencies": {
-        "@testing-library/react-native": "^13.1.0",
+        "@testing-library/react-native": "^13.0.0",
         "@types/jest": "^30.0.0",
         "@types/react": "~19.1.0",
         "@types/uuid": "^10.0.0",
         "babel-plugin-module-resolver": "^5.0.2",
         "babel-preset-expo": "~54.0.9",
         "baseline-browser-mapping": "^2.9.15",
-        "jest": "29.7.0",
+        "jest": "^29.7.0",
         "jest-expo": "~54.0.13",
         "react-test-renderer": "19.1.0",
         "typescript": "~5.9.2",
@@ -5712,9 +5713,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "19.0.21",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
-      "integrity": "sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg==",
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-55.0.11.tgz",
+      "integrity": "sha512-KMUd6OY375J9WD79ZvjvCDZMveT7YfgiGWdi58/gfuTBsr14TRuoPk8RRQHAtc4UquzWViKcHwna9aPY7/XPpw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -5957,6 +5958,16 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/expo/node_modules/expo-file-system": {
+      "version": "19.0.21",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
+      "integrity": "sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@react-navigation/native-stack": "^7.8.0",
     "babel-preset-expo": "~54.0.10",
     "expo": "~54.0.33",
+    "expo-file-system": "^55.0.11",
     "expo-font": "~14.0.11",
     "expo-image-manipulator": "~14.0.8",
     "expo-image-picker": "~17.0.10",
@@ -38,18 +39,18 @@
     "react-native-worklets": "0.5.1"
   },
   "devDependencies": {
+    "@testing-library/react-native": "^13.0.0",
+    "@types/jest": "^30.0.0",
     "@types/react": "~19.1.0",
     "@types/uuid": "^10.0.0",
     "babel-plugin-module-resolver": "^5.0.2",
     "babel-preset-expo": "~54.0.9",
     "baseline-browser-mapping": "^2.9.15",
-    "typescript": "~5.9.2",
-    "uuid": "^13.0.0",
     "jest": "^29.7.0",
     "jest-expo": "~54.0.13",
-    "@types/jest": "^30.0.0",
-    "@testing-library/react-native": "^13.0.0",
-    "react-test-renderer": "19.1.0"
+    "react-test-renderer": "19.1.0",
+    "typescript": "~5.9.2",
+    "uuid": "^13.0.0"
   },
   "private": true
 }


### PR DESCRIPTION
## 概要

`src/utils/photo.ts` で `expo-file-system/legacy` を import しているが、`package.json` の dependencies に `expo-file-system` が未登録だったため追加。

## 変更内容

- `package.json` に `expo-file-system` を追加
- `package-lock.json` を更新

## テスト

- Jest 自動テスト（photo utils）: 14件 全通過

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)