### PR TITLE
fix: 写真ライブラリ権限拒否時に設定アプリへ誘導するAlertを表示 (#77)

### DIFF
--- a/__tests__/photo.utils.jest.test.ts
+++ b/__tests__/photo.utils.jest.test.ts
@@ -21,19 +21,17 @@ import * as FileSystem from 'expo-file-system/legacy';
 import * as ImagePicker from 'expo-image-picker';
 import * as ImageManipulator from 'expo-image-manipulator';
 
-import { deleteIfExistsAsync, ensureFileExistsAsync, pickAndSavePhotoAsync } from '../src/utils/photo';
+import { deleteIfExistsAsync, ensureFileExistsAsync, pickAndSavePhotoAsync, PhotoPermissionDeniedError } from '../src/utils/photo';
 
 describe('photo utils', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  test('pickAndSavePhotoAsync returns null and warns when permission denied', async () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  test('pickAndSavePhotoAsync throws PhotoPermissionDeniedError when permission denied', async () => {
     (ImagePicker.requestMediaLibraryPermissionsAsync as jest.Mock).mockResolvedValue({ granted: false });
 
-    await expect(pickAndSavePhotoAsync()).resolves.toBeNull();
-    expect(warnSpy).toHaveBeenCalledWith('Media library permission denied');
+    await expect(pickAndSavePhotoAsync()).rejects.toThrow(PhotoPermissionDeniedError);
   });
 
   test('pickAndSavePhotoAsync returns null when picker canceled', async () => {

--- a/src/screens/RecordInputScreen.tsx
+++ b/src/screens/RecordInputScreen.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Button,
   Image,
+  Linking,
   Modal,
   Platform,
   Pressable,
@@ -26,7 +27,7 @@ import { SaveAchievementPayload, useAchievements } from "@/state/AchievementsCon
 import { useDateViewContext } from "@/state/DateViewContext";
 import { clampComment, remainingChars } from "@/utils/text";
 import { safeParseIsoLocal, toIsoDateString, toUtcDateOnly } from "@/utils/dateUtils";
-import { deleteIfExistsAsync, ensureFileExistsAsync, pickAndSavePhotoAsync } from "@/utils/photo";
+import { deleteIfExistsAsync, ensureFileExistsAsync, pickAndSavePhotoAsync, PhotoPermissionDeniedError } from "@/utils/photo";
 import { RECORD_TITLE_CANDIDATES } from "./recordTitleCandidates";
 import { COLORS } from "@/constants/colors";
 
@@ -142,6 +143,17 @@ const RecordInputScreen: React.FC<Props> = ({ navigation, route }) => {
       setPhotoPath(next);
       setHasRemovedPhoto(false);
     } catch (error) {
+      if (error instanceof PhotoPermissionDeniedError) {
+        Alert.alert(
+          "写真へのアクセスが許可されていません",
+          "写真を追加するには、設定アプリでこのアプリの写真アクセスを許可してください。",
+          [
+            { text: "キャンセル", style: "cancel" },
+            { text: "設定を開く", onPress: () => Linking.openSettings() },
+          ]
+        );
+        return;
+      }
       console.error("Failed to pick photo", error);
       Alert.alert("写真の追加に失敗しました", "再度お試しください。");
     }

--- a/src/utils/photo.ts
+++ b/src/utils/photo.ts
@@ -2,6 +2,13 @@ import * as FileSystem from "expo-file-system/legacy";
 import * as ImageManipulator from "expo-image-manipulator";
 import * as ImagePicker from "expo-image-picker";
 
+export class PhotoPermissionDeniedError extends Error {
+  constructor() {
+    super("Media library permission denied");
+    this.name = "PhotoPermissionDeniedError";
+  }
+}
+
 const PHOTO_DIR = `${FileSystem.documentDirectory}achievement-photos/`;
 const MAX_LONG_EDGE = 1600;
 const JPEG_QUALITY = 0.75;
@@ -44,8 +51,7 @@ const calculateResize = (width?: number, height?: number): ImageManipulator.Acti
 export const pickAndSavePhotoAsync = async (): Promise<string | null> => {
   const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
   if (!permission.granted) {
-    console.warn("Media library permission denied");
-    return null;
+    throw new PhotoPermissionDeniedError();
   }
 
   const result = await ImagePicker.launchImageLibraryAsync({


### PR DESCRIPTION
## 概要

写真選択時に権限が拒否された場合、`console.warn` のみで無言終了していた挙動を修正。
ユーザーに理由と対処方法を伝えるAlertを表示し、設定アプリへ誘導するようにした。

## 変更内容

- `src/utils/photo.ts`: `PhotoPermissionDeniedError` クラスを追加・export。権限拒否時に throw するよう変更
- `src/screens/RecordInputScreen.tsx`: `PhotoPermissionDeniedError` をcatchして「設定を開く」ボタン付きAlertを表示
- `__tests__/photo.utils.jest.test.ts`: 権限拒否テストを throw 検証に更新

## テスト

- Jest 自動テスト（photo utils）: 14件 全通過
- TypeScript 型チェック: エラーなし

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)