### PR TITLE
fix: Today画面の空状態ボタンをアプリデザインに統一、月齢表記ラベルを改善 (#87 #94)

### DIFF
--- a/src/screens/ProfileEditScreen.tsx
+++ b/src/screens/ProfileEditScreen.tsx
@@ -286,8 +286,8 @@ const ProfileEditScreen: React.FC<Props> = ({ navigation, route }) => {
             <Text style={styles.label}>月齢表記</Text>
             <View style={styles.optionRow}>
               {[
-                { label: "才ヶ月日", value: "ymd" },
-                { label: "ヶ月日", value: "md" },
+                { label: "〇才〇ヵ月〇日", value: "ymd" },
+                { label: "〇〇ヵ月〇日", value: "md" },
               ].map((option) => (
                 <Pressable
                   key={option.value}

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -2,7 +2,7 @@
 // Renaming to DayScreen is deferred for future refactor.
 
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Alert, Button, Image, ImageBackground, SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { Alert, Image, ImageBackground, SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 import * as MediaLibrary from "expo-media-library";
 import ViewShot from "react-native-view-shot";
@@ -154,10 +154,12 @@ const TodayScreen: React.FC<Props> = ({ navigation: stackNavigation, route }) =>
           <Text style={styles.title}>プロフィールを作成してください</Text>
           <Text style={styles.subtitle}>最初にプロフィール設定から始めましょう</Text>
           <View style={styles.buttonRow}>
-            <Button
-              title="設定へ"
+            <TouchableOpacity
+              style={styles.navButton}
               onPress={() => rootNavigation.navigate("SettingsStack", { screen: "ProfileManager" })}
-            />
+            >
+              <Text style={styles.navButtonText}>設定へ</Text>
+            </TouchableOpacity>
           </View>
         </View>
       </SafeAreaView>
@@ -170,10 +172,12 @@ const TodayScreen: React.FC<Props> = ({ navigation: stackNavigation, route }) =>
         <View style={styles.container}>
           <Text style={styles.title}>{user.name}</Text>
           <Text style={styles.subtitle}>生年月日が未設定です</Text>
-          <Button
-            title="プロフィールを編集"
+          <TouchableOpacity
+            style={styles.navButton}
             onPress={() => rootNavigation.navigate("SettingsStack", { screen: "ProfileManager" })}
-          />
+          >
+            <Text style={styles.navButtonText}>プロフィールを編集</Text>
+          </TouchableOpacity>
         </View>
       </SafeAreaView>
     );
@@ -445,6 +449,21 @@ const styles = StyleSheet.create({
   },
   buttonRow: {
     marginTop: 12,
+  },
+  navButton: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: COLORS.filterBackground,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+  },
+  navButtonText: {
+    color: COLORS.textPrimary,
+    fontWeight: "600",
+    fontSize: 14,
   },
   hiddenRenderer: {
     position: "absolute",


### PR DESCRIPTION
## 概要

2つのUIバグを修正。

## 変更内容

### #87 Today画面：プロフィール未設定時の色味が他と違う
- `TodayScreen` のプロフィール未設定・生年月日未設定時に使っていた `Button`（iOS標準の青ボタン）を `TouchableOpacity` に置き換え
- `COLORS.filterBackground`（緑）ベースのスタイルに統一し、他画面と色味を合わせた

### #94 プロフィール編集画面：月齢表記ラベルが分かりづらい
- `ProfileEditScreen` の月齢表記選択肢を変更
  - `才ヶ月日` → `〇才〇ヵ月〇日`
  - `ヶ月日` → `〇〇ヵ月〇日`

## テスト

- Jest 自動テスト: 136件 全通過
- TypeScript 型チェック: エラーなし

Closes #87
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)