### PR TITLE
feat: 記録詳細画面に月齢・修正月齢・生まれてからの日数を表示 (#100)

### DIFF
--- a/src/screens/RecordDetailScreen.tsx
+++ b/src/screens/RecordDetailScreen.tsx
@@ -8,6 +8,7 @@ import { RootStackParamList } from "@/navigation";
 import AppText from "@/components/AppText";
 import { useActiveUser } from "@/state/AppStateContext";
 import { useAchievements } from "@/state/AchievementsContext";
+import { calculateAgeInfo } from "@/utils/dateUtils";
 import { ensureFileExistsAsync } from "@/utils/photo";
 import { COLORS } from "@/constants/colors";
 
@@ -29,6 +30,21 @@ const RecordDetailScreen: React.FC<Props> = ({ navigation, route }) => {
     const all = Object.values(store).flat();
     return all.find((item) => item.id === recordId) ?? null;
   }, [isoDate, recordId, store]);
+
+  const ageInfo = useMemo(() => {
+    if (!user?.birthDate || !record) return null;
+    try {
+      return calculateAgeInfo({
+        targetDate: record.date,
+        birthDate: user.birthDate,
+        dueDate: user.dueDate,
+        showCorrectedUntilMonths: user.settings.showCorrectedUntilMonths,
+        ageFormat: user.settings.ageFormat,
+      });
+    } catch {
+      return null;
+    }
+  }, [user, record]);
 
   useEffect(() => {
     let mounted = true;
@@ -83,6 +99,32 @@ const RecordDetailScreen: React.FC<Props> = ({ navigation, route }) => {
           <Text style={styles.label}>日付</Text>
           <Text style={styles.value}>{record.date.replace(/-/g, "/")}</Text>
         </View>
+
+        {ageInfo ? (
+          <View style={styles.field}>
+            <Text style={styles.label}>月齢</Text>
+            <View style={styles.ageBlock}>
+              {ageInfo.flags.showMode === "gestational" && ageInfo.gestational.visible && ageInfo.gestational.formatted ? (
+                <View style={styles.ageRow}>
+                  <Text style={styles.ageValue}>{ageInfo.chronological.formatted}</Text>
+                  <Text style={styles.ageNote}>（在胎 {ageInfo.gestational.formatted}）</Text>
+                </View>
+              ) : ageInfo.corrected.visible && ageInfo.corrected.formatted ? (
+                <View style={styles.ageRow}>
+                  <Text style={styles.ageValue}>{ageInfo.chronological.formatted}</Text>
+                  <Text style={styles.ageNote}>（修正 {ageInfo.corrected.formatted}）</Text>
+                </View>
+              ) : (
+                <View style={styles.ageRow}>
+                  <Text style={styles.ageValue}>{ageInfo.chronological.formatted}</Text>
+                </View>
+              )}
+              {user?.settings.showDaysSinceBirth ? (
+                <Text style={styles.ageNote}>生まれてから{ageInfo.daysSinceBirth}日目</Text>
+              ) : null}
+            </View>
+          </View>
+        ) : null}
 
         <View style={styles.field}>
           <Text style={styles.label}>タイトル</Text>
@@ -144,6 +186,23 @@ const styles = StyleSheet.create({
   value: {
     fontSize: 17,
     color: COLORS.textPrimary,
+  },
+  ageBlock: {
+    gap: 4,
+  },
+  ageRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    flexWrap: "wrap",
+  },
+  ageValue: {
+    fontSize: 17,
+    color: COLORS.textPrimary,
+  },
+  ageNote: {
+    fontSize: 14,
+    color: COLORS.textSecondary,
   },
   actions: {
     marginTop: 12,


### PR DESCRIPTION
## 概要

記録詳細画面の日付フィールド直下に、その日の月齢情報を表示するよう追加。

## 変更内容

- `RecordDetailScreen.tsx`: `record.date` を基準に `calculateAgeInfo` を呼び出し、以下を表示
  - 暦月齢（常時表示）
  - 修正月齢または在胎週数（設定・期間に応じて表示）
  - 生まれてからの日数（ユーザー設定 `showDaysSinceBirth` が有効な場合）
- 表示ロジック・スタイルは TodayScreen と統一

## テスト

- Jest 自動テスト: 136件 全通過
- TypeScript 型チェック: エラーなし

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)