### PR TITLE
fix: 検索の半角全角対応・iOSコンテキストメニュー日本語化 (#103 #93)

### DIFF
--- a/__tests__/text.utils.jest.test.ts
+++ b/__tests__/text.utils.jest.test.ts
@@ -18,6 +18,13 @@ describe('text utils exports', () => {
     expect(normalizeSearchText(' ＡＢＣ　１２3  Test ')).toBe('abc 123 test');
   });
 
+  test('normalizeSearchText converts half-width katakana to full-width', () => {
+    expect(normalizeSearchText('ﾃｽﾄ')).toBe('テスト');
+    expect(normalizeSearchText('ﾊﾝｶｸ')).toBe('ハンカク');
+    // 半角・全角どちらで検索しても同じ結果になる
+    expect(normalizeSearchText('ﾃｽﾄ')).toBe(normalizeSearchText('テスト'));
+  });
+
   test('remainingChars and clampComment handle undefined input through nullish fallback branches', () => {
     expect(remainingChars(undefined as unknown as string)).toBe(500);
     expect(clampComment(undefined as unknown as string)).toBeUndefined();

--- a/app.json
+++ b/app.json
@@ -13,7 +13,11 @@
       "backgroundColor": "#FFFFFF"
     },
     "ios": {
-      "supportsTablet": false
+      "supportsTablet": false,
+      "infoPlist": {
+        "CFBundleDevelopmentRegion": "ja_JP",
+        "CFBundleLocalizations": ["ja"]
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -9,17 +9,15 @@ export const clampComment = (s: string): string => {
 };
 
 /**
- * 検索用に軽微な正規化を行う。
+ * 検索用に正規化を行う。
+ * - NFKC正規化（半角カタカナ→全角・全角英数→半角など）
  * - 英字を小文字化
- * - 全角英数を半角へ変換
  * - 連続した空白を 1 つにまとめて前後を trim
  */
 export const normalizeSearchText = (value?: string | null): string => {
   if (!value) return "";
-  const toHalfWidth = value.replace(/[Ａ-Ｚａ-ｚ０-９]/g, (ch) =>
-    String.fromCharCode(ch.charCodeAt(0) - 0xfee0)
-  );
-  return toHalfWidth
+  return value
+    .normalize("NFKC")
     .toLowerCase()
     .replace(/\s+/g, " ")
     .trim();


### PR DESCRIPTION
## 概要

2つのバグを修正。

## 変更内容

### #103 記録一覧の検索で半角全角対応がされていない
- `src/utils/text.ts`: `normalizeSearchText` を `String.normalize('NFKC')` ベースに変更
- 半角カタカナ（ｱｲｳ）→全角カタカナ（アイウ）に統一されるため、半角・全角どちらで検索しても同じ結果になる
- 全角英数→半角の変換も引き続き動作（NFKC が包含する）

### #93 テキストボックスの英語コンテキストメニュー
- `app.json` の iOS `infoPlist` に `CFBundleLocalizations: ["ja"]` と `CFBundleDevelopmentRegion: "ja_JP"` を追加
- iOSがアプリを日本語対応と認識し、「選択」「コピー」「貼り付け」等のメニューが日本語で表示されるようになる

## テスト

- Jest 自動テスト: 137件 全通過（半角カタカナテスト3件追加）
- TypeScript 型チェック: エラーなし

> ⚠️ #93 は `app.json` の変更のため、実機ビルドでの確認が必要です

Closes #103
Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)