### PR TITLE
fix: 記録詳細画面から「記録詳細」テキストとタイトルフィールドを削除

### DIFF
--- a/src/screens/RecordDetailScreen.tsx
+++ b/src/screens/RecordDetailScreen.tsx
@@ -93,6 +93,7 @@ const RecordDetailScreen: React.FC<Props> = ({ navigation, route }) => {
         <View style={styles.headerRight} />
       </View>
       <View style={styles.container}>
+        <Text style={styles.title}>{record.title || "(タイトル未入力)"}</Text>
         <View style={styles.field}>
           <Text style={styles.label}>日付</Text>
           <Text style={styles.value}>{record.date.replace(/-/g, "/")}</Text>

--- a/src/screens/RecordDetailScreen.tsx
+++ b/src/screens/RecordDetailScreen.tsx
@@ -93,8 +93,6 @@ const RecordDetailScreen: React.FC<Props> = ({ navigation, route }) => {
         <View style={styles.headerRight} />
       </View>
       <View style={styles.container}>
-        <Text style={styles.title}>記録詳細</Text>
-
         <View style={styles.field}>
           <Text style={styles.label}>日付</Text>
           <Text style={styles.value}>{record.date.replace(/-/g, "/")}</Text>
@@ -125,11 +123,6 @@ const RecordDetailScreen: React.FC<Props> = ({ navigation, route }) => {
             </View>
           </View>
         ) : null}
-
-        <View style={styles.field}>
-          <Text style={styles.label}>タイトル</Text>
-          <Text style={styles.value}>{record.title || "(タイトル未入力)"}</Text>
-        </View>
 
         {record.memo ? (
           <View style={styles.field}>


### PR DESCRIPTION
## Summary
- ヘッダーに「花子の記録」形式で表示されているため、コンテンツ内の「記録詳細」テキストを削除
- 「タイトル」フィールド（ラベルと値）を削除

fix #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)