### PR TITLE
fix: カレンダー出生日セルに「誕生日」ラベルを表示する

### DIFF
--- a/__tests__/dateUtils.full.jest.test.ts
+++ b/__tests__/dateUtils.full.jest.test.ts
@@ -139,7 +139,7 @@ describe('dateUtils exported functions', () => {
 
     const jan30 = view.days.find((d) => d.date === '2025-01-30');
     const jan29 = view.days.find((d) => d.date === '2025-01-29');
-    expect(jan30?.calendarAgeLabel?.chronological).toBe('暦 0才0ヶ月');
+    expect(jan30?.calendarAgeLabel?.chronological).toBe('誕生日');
     expect(jan29?.calendarAgeLabel?.chronological).toBeUndefined();
   });
 

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -336,7 +336,7 @@ export const buildCalendarMonthView = ({
       ageInfo && (chronologicalChanged || correctedChanged || gestationalChanged)
         ? {
             chronological: chronologicalChanged
-              ? formatCalendarAgeLabel(ageInfo.chronological, settings.ageFormat, false)
+              ? (isBirthDay ? "誕生日" : formatCalendarAgeLabel(ageInfo.chronological, settings.ageFormat, false))
               : undefined,
             corrected: correctedChanged
               ? (() => {


### PR DESCRIPTION
## 修正内容

`buildCalendarMonthView` にて、出生日（`iso === birthDate`）のセルの `calendarAgeLabel.chronological` を `"誕生日"` に固定する。

修正前は `isBirthDay = true` → `chronologicalChanged = true` となっていたが、ラベルには `formatCalendarAgeLabel` の結果（`"0才0ヵ月"`）がそのまま入っていた。

## 変更ファイル

- `src/utils/dateUtils.ts` — 出生日判定時のラベルを `"誕生日"` に変更
- `__tests__/dateUtils.full.jest.test.ts` — 期待値を `'暦 0才0ヶ月'` → `'誕生日'` に更新

## 確認手順

1. 出生日のある月をカレンダーで開く
2. 出生日のセルに「誕生日」ラベルが表示されることを確認

Closes #92