### PR TITLE
fix: 早産児の出生日セルに在胎週数ラベルを表示する

### DIFF
--- a/__tests__/dateUtils.full.jest.test.ts
+++ b/__tests__/dateUtils.full.jest.test.ts
@@ -153,6 +153,28 @@ describe('dateUtils exported functions', () => {
     expect(daysBetweenUtc(new Date(2025, 0, 1), new Date(NaN))).toBe(0);
   });
 
+  test('buildCalendarMonthView shows gestational label on birth date for preterm baby', () => {
+    // 出生日: 2025-03-10, 予定日: 2025-05-19 (70日早産 → 在胎30週0日)
+    const view = buildCalendarMonthView({
+      anchorDate: new Date(2025, 2, 1),
+      settings,
+      birthDate: '2025-03-10',
+      dueDate: '2025-05-19',
+    });
+
+    const birthDay = view.days.find((d) => d.date === '2025-03-10');
+    const dayBefore = view.days.find((d) => d.date === '2025-03-09');
+    const oneWeekLater = view.days.find((d) => d.date === '2025-03-17');
+
+    // 出生日は在胎ラベルと暦ラベルを両方持つ
+    expect(birthDay?.calendarAgeLabel?.gestational).toBe('在胎 30週0日');
+    expect(birthDay?.calendarAgeLabel?.chronological).toBe('暦 0才0ヶ月');
+    // 前日は在胎ラベルなし（週が変わっていない）
+    expect(dayBefore?.calendarAgeLabel?.gestational).toBeUndefined();
+    // 1週後は在胎ラベルあり（週が進んだ）
+    expect(oneWeekLater?.calendarAgeLabel?.gestational).toBe('在胎 31週0日');
+  });
+
   test('buildCalendarMonthView fallback injects chronological label when month has no chronological changes', () => {
     const view = buildCalendarMonthView({
       anchorDate: new Date(2025, 1, 1),

--- a/__tests__/dateUtils.full.jest.test.ts
+++ b/__tests__/dateUtils.full.jest.test.ts
@@ -168,7 +168,7 @@ describe('dateUtils exported functions', () => {
 
     // 出生日は在胎ラベルと暦ラベルを両方持つ
     expect(birthDay?.calendarAgeLabel?.gestational).toBe('在胎 30週0日');
-    expect(birthDay?.calendarAgeLabel?.chronological).toBe('暦 0才0ヶ月');
+    expect(birthDay?.calendarAgeLabel?.chronological).toBe('誕生日');
     // 前日は在胎ラベルなし（週が変わっていない）
     expect(dayBefore?.calendarAgeLabel?.gestational).toBeUndefined();
     // 1週後は在胎ラベルあり（週が進んだ）

--- a/src/components/DayCell.tsx
+++ b/src/components/DayCell.tsx
@@ -40,12 +40,18 @@ const DayCell: React.FC<Props> = ({ day, onPress, gridPos }) => {
   let bottomStickerStyle = styles.ageStickerChronological;
   let bottomTextStyle = styles.ageTextChronological;
 
-  if (normalizedGestationalLabel != null) {
-    // 誕生日前（在胎表示期間）は暦月齢を出さない。
+  if (normalizedGestationalLabel != null && normalizedChronologicalLabel == null) {
+    // 誕生日前（在胎表示期間）: 在胎のみ表示、暦月齢は出さない。
     topLabel = normalizedGestationalLabel;
     topStickerStyle = styles.ageStickerGestational;
     topTextStyle = styles.ageTextGestational;
     bottomLabel = null;
+  } else if (normalizedGestationalLabel != null) {
+    // 出生日: 暦（誕生日）をtop、在胎をbottomに並べて表示。
+    // topLabel はデフォルトの normalizedChronologicalLabel のまま。
+    bottomLabel = normalizedGestationalLabel;
+    bottomStickerStyle = styles.ageStickerGestational;
+    bottomTextStyle = styles.ageTextGestational;
   } else if (normalizedCorrectedLabel != null) {
     topLabel = normalizedChronologicalLabel;
     topStickerStyle = styles.ageStickerChronological;

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -330,7 +330,8 @@ export const buildCalendarMonthView = ({
     const gestationalChanged =
       gestationalVisible &&
       ((previousGestationalVisible && ageInfo!.gestational.weeks === previousAgeInfo!.gestational.weeks + 1) ||
-        !previousGestationalVisible);
+        !previousGestationalVisible ||
+        isBirthDay); // 出生日は前日と在胎週数が同じになるため強制表示
 
     let calendarAgeLabel =
       ageInfo && (chronologicalChanged || correctedChanged || gestationalChanged)


### PR DESCRIPTION
## 原因

出生日の前日は `targetDate < birthDate` のため `daysBetweenUtc` が 0 を返し、前日と出生日の在胎週数が同一になる。その結果 `gestationalChanged` が `false` となり、出生日で在胎ラベルが生成されなかった。

## 修正内容

**`src/utils/dateUtils.ts`**
- `gestationalChanged` の条件に `|| isBirthDay` を追加
- 出生日は前日と在胎週数が同じでも強制的に在胎ラベルを表示する

**`src/components/DayCell.tsx`**
- `gestationalLabel` と `chronologicalLabel` が両方ある場合（出生日のみ）は chronological を top、gestational を bottom に並べて両方表示する
- 通常の在胎期間（誕生日前）は従来どおり gestational のみを top に表示

**`__tests__/dateUtils.full.jest.test.ts`**
- 早産児の出生日で在胎ラベルが生成されることを確認するテストを追加

## 確認手順

1. 早産設定（出生日・出産予定日ともに設定）でカレンダーを開く
2. 出生日のセルに在胎週数ラベルが表示されることを確認
3. 出生日の前日・翌日の在胎ラベルが正常に表示されることを確認（週が変わるタイミングのみ表示）

## 影響範囲

- 変更は出生日セルのみに影響（`isBirthDay` フラグで限定）
- 通常の在胎期間・修正月齢・暦月齢のロジックは変更なし

Closes #95