### PR TITLE
fix: 全画面のヘッダーをカスタムヘッダーに統一 #106

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -63,27 +63,11 @@ const SettingsStackNavigator: React.FC = () => (
     <SettingsStack.Screen name="Settings" component={SettingsScreen} />
     <SettingsStack.Screen name="ProfileEdit" component={ProfileEditScreen} />
     <SettingsStack.Screen name="ProfileManager" component={ProfileManagerScreen} />
-    <SettingsStack.Screen
-      name="About"
-      component={AboutScreen}
-      options={{ headerShown: true, title: "このアプリについて" }}
-    />
-    <SettingsStack.Screen
-      name="PrivacyPolicy"
-      component={PrivacyPolicyScreen}
-      options={{ headerShown: true, title: "プライバシーポリシー" }}
-    />
-    <SettingsStack.Screen name="Terms" component={TermsScreen} options={{ headerShown: true, title: "利用規約" }} />
-    <SettingsStack.Screen
-      name="OpenSourceLicenses"
-      component={OpenSourceLicensesScreen}
-      options={{ headerShown: true, title: "オープンソースライセンス" }}
-    />
-    <SettingsStack.Screen
-      name="Contact"
-      component={ContactScreen}
-      options={{ headerShown: true, title: "お問い合わせ" }}
-    />
+    <SettingsStack.Screen name="About" component={AboutScreen} />
+    <SettingsStack.Screen name="PrivacyPolicy" component={PrivacyPolicyScreen} />
+    <SettingsStack.Screen name="Terms" component={TermsScreen} />
+    <SettingsStack.Screen name="OpenSourceLicenses" component={OpenSourceLicensesScreen} />
+    <SettingsStack.Screen name="Contact" component={ContactScreen} />
   </SettingsStack.Navigator>
 );
 

--- a/src/screens/AboutScreen.tsx
+++ b/src/screens/AboutScreen.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+
 import { ABOUT_TEXT_JA } from "@/content/legal/ja";
+import { SettingsStackParamList } from "@/navigation";
 import LegalTextScreen from "@/screens/LegalTextScreen";
 
-const AboutScreen: React.FC = () => {
-  return <LegalTextScreen text={ABOUT_TEXT_JA} />;
+type Props = NativeStackScreenProps<SettingsStackParamList, "About">;
+
+const AboutScreen: React.FC<Props> = ({ navigation }) => {
+  return <LegalTextScreen text={ABOUT_TEXT_JA} title="このアプリについて" onBack={() => navigation.goBack()} />;
 };
 
 export default AboutScreen;

--- a/src/screens/ContactScreen.tsx
+++ b/src/screens/ContactScreen.tsx
@@ -1,13 +1,19 @@
 import React, { useCallback } from "react";
 import { Alert, Linking, SafeAreaView, ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
 
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { Ionicons } from "@expo/vector-icons";
+
 import AppText from "@/components/AppText";
 import { LEGAL_META } from "@/content/legal/ja";
+import { SettingsStackParamList } from "@/navigation";
 import { COLORS } from "@/constants/colors";
+
+type Props = NativeStackScreenProps<SettingsStackParamList, "Contact">;
 
 const SUPPORT_EMAIL = LEGAL_META.contactEmail;
 
-const ContactScreen: React.FC = () => {
+const ContactScreen: React.FC<Props> = ({ navigation }) => {
   const handlePressEmail = useCallback(async () => {
     const encodedSubject = encodeURIComponent("お問い合わせ");
     const mailtoUrl = `mailto:${SUPPORT_EMAIL}?subject=${encodedSubject}`;
@@ -23,6 +29,12 @@ const ContactScreen: React.FC = () => {
 
   return (
     <SafeAreaView style={styles.safeArea}>
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backButton} onPress={() => navigation.goBack()} accessibilityRole="button" accessibilityLabel="戻る">
+          <Ionicons name="chevron-back" size={22} color={COLORS.textPrimary} />
+        </TouchableOpacity>
+        <AppText style={styles.headerTitle} weight="medium">お問い合わせ</AppText>
+      </View>
       <ScrollView contentContainerStyle={styles.container}>
         <AppText style={styles.description}>
           ご意見・ご不明点がございましたら、以下のメールアドレスまでご連絡ください。
@@ -47,6 +59,23 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
     backgroundColor: COLORS.background,
+  },
+  header: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: COLORS.headerBackground,
+  },
+  backButton: {
+    position: "absolute",
+    left: 16,
+    padding: 6,
+  },
+  headerTitle: {
+    fontSize: 18,
+    color: COLORS.textPrimary,
+    textAlign: "center",
   },
   container: {
     padding: 24,

--- a/src/screens/LegalTextScreen.tsx
+++ b/src/screens/LegalTextScreen.tsx
@@ -1,18 +1,28 @@
 import React from "react";
-import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native";
+import { SafeAreaView, ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
+
+import { Ionicons } from "@expo/vector-icons";
 
 import AppText from "@/components/AppText";
 import { COLORS } from "@/constants/colors";
 
 type Props = {
   text: string;
+  title: string;
+  onBack: () => void;
 };
 
-const LegalTextScreen: React.FC<Props> = ({ text }) => {
+const LegalTextScreen: React.FC<Props> = ({ text, title, onBack }) => {
   const lines = text.split("\n");
 
   return (
     <SafeAreaView style={styles.safeArea}>
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backButton} onPress={onBack} accessibilityRole="button" accessibilityLabel="戻る">
+          <Ionicons name="chevron-back" size={22} color={COLORS.textPrimary} />
+        </TouchableOpacity>
+        <AppText style={styles.headerTitle} weight="medium">{title}</AppText>
+      </View>
       <ScrollView contentContainerStyle={styles.container}>
         {lines.map((line, index) => {
           const trimmed = line.trim();
@@ -56,6 +66,23 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
     backgroundColor: COLORS.background,
+  },
+  header: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: COLORS.headerBackground,
+  },
+  backButton: {
+    position: "absolute",
+    left: 16,
+    padding: 6,
+  },
+  headerTitle: {
+    fontSize: 18,
+    color: COLORS.textPrimary,
+    textAlign: "center",
   },
   container: {
     padding: 24,

--- a/src/screens/OpenSourceLicensesScreen.tsx
+++ b/src/screens/OpenSourceLicensesScreen.tsx
@@ -1,16 +1,25 @@
 import React from "react";
-import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native";
+import { SafeAreaView, ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
+
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { Ionicons } from "@expo/vector-icons";
 
 import AppText from "@/components/AppText";
+import { SettingsStackParamList } from "@/navigation";
 import { COLORS } from "@/constants/colors";
 
-const OpenSourceLicensesScreen: React.FC = () => {
+type Props = NativeStackScreenProps<SettingsStackParamList, "OpenSourceLicenses">;
+
+const OpenSourceLicensesScreen: React.FC<Props> = ({ navigation }) => {
   return (
     <SafeAreaView style={styles.safeArea}>
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backButton} onPress={() => navigation.goBack()} accessibilityRole="button" accessibilityLabel="戻る">
+          <Ionicons name="chevron-back" size={22} color={COLORS.textPrimary} />
+        </TouchableOpacity>
+        <AppText style={styles.headerTitle} weight="medium">オープンソースライセンス</AppText>
+      </View>
       <ScrollView contentContainerStyle={styles.container}>
-        <AppText style={styles.title} weight="medium">
-          オープンソースライセンス
-        </AppText>
         <View style={styles.card}>
           <AppText style={styles.text}>準備中</AppText>
           <AppText style={styles.subText}>
@@ -27,14 +36,26 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: COLORS.background,
   },
+  header: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: COLORS.headerBackground,
+  },
+  backButton: {
+    position: "absolute",
+    left: 16,
+    padding: 6,
+  },
+  headerTitle: {
+    fontSize: 18,
+    color: COLORS.textPrimary,
+    textAlign: "center",
+  },
   container: {
     padding: 24,
     gap: 16,
-  },
-  title: {
-    fontSize: 24,
-    lineHeight: 34,
-    color: COLORS.textPrimary,
   },
   card: {
     borderRadius: 12,

--- a/src/screens/PrivacyPolicyScreen.tsx
+++ b/src/screens/PrivacyPolicyScreen.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+
 import { PRIVACY_POLICY_TEXT_JA } from "@/content/legal/ja";
+import { SettingsStackParamList } from "@/navigation";
 import LegalTextScreen from "@/screens/LegalTextScreen";
 
-const PrivacyPolicyScreen: React.FC = () => {
-  return <LegalTextScreen text={PRIVACY_POLICY_TEXT_JA} />;
+type Props = NativeStackScreenProps<SettingsStackParamList, "PrivacyPolicy">;
+
+const PrivacyPolicyScreen: React.FC<Props> = ({ navigation }) => {
+  return <LegalTextScreen text={PRIVACY_POLICY_TEXT_JA} title="プライバシーポリシー" onBack={() => navigation.goBack()} />;
 };
 
 export default PrivacyPolicyScreen;

--- a/src/screens/TermsScreen.tsx
+++ b/src/screens/TermsScreen.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+
 import { TERMS_TEXT_JA } from "@/content/legal/ja";
+import { SettingsStackParamList } from "@/navigation";
 import LegalTextScreen from "@/screens/LegalTextScreen";
 
-const TermsScreen: React.FC = () => {
-  return <LegalTextScreen text={TERMS_TEXT_JA} />;
+type Props = NativeStackScreenProps<SettingsStackParamList, "Terms">;
+
+const TermsScreen: React.FC<Props> = ({ navigation }) => {
+  return <LegalTextScreen text={TERMS_TEXT_JA} title="利用規約" onBack={() => navigation.goBack()} />;
 };
 
 export default TermsScreen;


### PR DESCRIPTION
## 修正内容

ネイティブヘッダーを廃止し、全画面で `<` (chevron-back) のカスタムヘッダーに統一。

iOS ではネイティブヘッダーの背景色がステータスバー（時刻・電池表示部分）まで拡張されてしまい、画面によって緑色になる問題があったため、全面的にカスタムヘッダーへ変更。

### 対象画面

- **このアプリについて / プライバシーポリシー / 利用規約**
  - `LegalTextScreen` に `title`・`onBack` props を追加してヘッダーを組み込み
  - 各画面（About/PrivacyPolicy/Terms）が navigation props を受け取るよう変更
- **オープンソースライセンス**
- **お問い合わせ**

## 確認手順

1. 設定 → 各画面（このアプリについて・プライバシーポリシー・利用規約・オープンソースライセンス・お問い合わせ）を開く
2. ヘッダーに `<` ボタンとタイトルが表示されること
3. `<` ボタンで前の画面に戻れること
4. iOS ステータスバー（時刻・電池部分）が白いままであること

Closes #106