### PR TITLE
fix: 出生日前のセルに在胎週数ラベルが表示されるバグを修正

### DIFF
--- a/__tests__/age.dateUtils.jest.test.ts
+++ b/__tests__/age.dateUtils.jest.test.ts
@@ -13,6 +13,13 @@ describe('calculateAgeInfo', () => {
     expect(beforeDue.gestational.visible).toBe(true);
     expect(onDue.corrected.formatted).toBe('0ヶ月0日');
   });
+
+  test('gestational is not visible before birth date', () => {
+    // 出生日前は在胎表示しない（#89）
+    const beforeBirth = calculateAgeInfo({ targetDate: '2026-02-01', birthDate: '2026-03-18', dueDate: '2026-05-18', showCorrectedUntilMonths: null, ageFormat: 'md' });
+    expect(beforeBirth.gestational.visible).toBe(false);
+    expect(beforeBirth.gestational.formatted).toBeNull();
+  });
 });
 
 describe('buildCalendarMonthView', () => {

--- a/__tests__/dateUtils.full.jest.test.ts
+++ b/__tests__/dateUtils.full.jest.test.ts
@@ -153,6 +153,20 @@ describe('dateUtils exported functions', () => {
     expect(daysBetweenUtc(new Date(2025, 0, 1), new Date(NaN))).toBe(0);
   });
 
+  test('buildCalendarMonthView shows no gestational label on cells before birth date', () => {
+    // 出生日: 2026-03-18, 予定日: 2026-05-18 → 出生前の2月はラベルなし（#89）
+    const view = buildCalendarMonthView({
+      anchorDate: new Date(2026, 1, 1), // 2月
+      settings,
+      birthDate: '2026-03-18',
+      dueDate: '2026-05-18',
+    });
+
+    const allCurrentMonth = view.days.filter((d) => d.isCurrentMonth);
+    const gestationalLabels = allCurrentMonth.filter((d) => d.calendarAgeLabel?.gestational != null);
+    expect(gestationalLabels).toHaveLength(0);
+  });
+
   test('buildCalendarMonthView fallback injects chronological label when month has no chronological changes', () => {
     const view = buildCalendarMonthView({
       anchorDate: new Date(2025, 1, 1),

--- a/src/components/DayCell.tsx
+++ b/src/components/DayCell.tsx
@@ -40,7 +40,12 @@ const DayCell: React.FC<Props> = ({ day, onPress, gridPos }) => {
   let bottomStickerStyle = styles.ageStickerChronological;
   let bottomTextStyle = styles.ageTextChronological;
 
-  if (normalizedGestationalLabel != null) {
+  if (normalizedGestationalLabel != null && normalizedChronologicalLabel != null) {
+    // 誕生日かつ在胎表示期間：「誕生日」を上、在胎週数を下に表示する。
+    bottomLabel = normalizedGestationalLabel;
+    bottomStickerStyle = styles.ageStickerGestational;
+    bottomTextStyle = styles.ageTextGestational;
+  } else if (normalizedGestationalLabel != null) {
     // 誕生日前（在胎表示期間）は暦月齢を出さない。
     topLabel = normalizedGestationalLabel;
     topStickerStyle = styles.ageStickerGestational;

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -199,7 +199,8 @@ export const calculateAgeInfo = (params: {
   const gestationAtTargetDays = gestationAtBirthDays + daysSinceBirth;
   const gestationalWeeks = Math.floor(gestationAtTargetDays / 7);
   const gestationalDays = gestationAtTargetDays % 7;
-  const gestationalVisible = Boolean(due) && isPreterm && isBeforeDue;
+  const gestationalVisible = Boolean(due) && isPreterm && isBeforeDue
+    && utcDateMs(target) >= utcDateMs(birth); // 出生日前は在胎非表示
 
   const showMode: AgeInfo["flags"]["showMode"] = !isPreterm
     ? "chronologicalOnly"


### PR DESCRIPTION
## 原因

`calculateAgeInfo` の `gestationalVisible` が `isBeforeDue`（目標日 < 予定日）しか確認しておらず、出生日**前**の日付でも `true` になっていた。

出生日前は `daysSinceBirth` が 0 にクランプされるため全日付が同じ在胎週数を返し、`buildCalendarMonthView` 内で `previousAgeInfo=null` からリセットされるタイミング（月の最初のセルが当月の場合＝月が日曜始まりのとき）でラベルが表示されていた。

## 修正内容

**`src/utils/dateUtils.ts`（1行追加）**

```ts
// Before
const gestationalVisible = Boolean(due) && isPreterm && isBeforeDue;

// After
const gestationalVisible = Boolean(due) && isPreterm && isBeforeDue
  && utcDateMs(target) >= utcDateMs(birth); // 出生日前は在胎非表示
```

## テスト追加

- `age.dateUtils.jest.test.ts`: 出生日前の `gestational.visible = false` を確認
- `dateUtils.full.jest.test.ts`: 出生前の月のカレンダーに在胎ラベルが出ないことを確認

## 確認手順

1. 出生日・出産予定日を設定（例: 出生日 2026-03-18、予定日 2026-05-18）
2. 出生日より前の月（2月など）をカレンダーで開く
3. 在胎週数ラベルが一切表示されないことを確認
4. 出生日のある月（3月）を開き、出生日セルに在胎ラベルが表示されることを確認

Closes #89