### PR TITLE
fix: Today画面で出生日前の月齢・日数表示を非表示にする

### DIFF
--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -211,7 +211,7 @@ const TodayScreen: React.FC<Props> = ({ navigation: stackNavigation, route }) =>
           </View>
         )}
 
-        {ageInfo ? (
+        {ageInfo && selectedDateIso >= user.birthDate ? (
           <View style={styles.ageBlock}>
             {ageInfo.flags.showMode === "gestational" && ageInfo.gestational.visible && ageInfo.gestational.formatted ? (
               <View style={styles.ageRow}>


### PR DESCRIPTION
## 原因

出生日前の日付は `calculateAgeInfo` が値を返すため（暦月齢は0にクランプ、`daysSinceBirth=0`）、`ageInfo` が `null` にならず月齢ブロックが描画されていた。

## 修正内容

**`src/screens/TodayScreen.tsx`（1行変更）**

```tsx
// Before
{ageInfo ? (

// After
{ageInfo && selectedDateIso >= user.birthDate ? (
```

出生日前の日付では月齢ブロック（暦月齢・在胎週数・修正月齢・生まれてからの日数）を一切表示しない。

## 確認手順

1. 出生日・出産予定日を設定（例: 出生日 2026-03-18、予定日 2026-05-18）
2. カレンダーで出生日より前の日付をタップ
3. Today画面に月齢・日数が表示されないことを確認
4. 出生日当日・以降は従来どおり表示されることを確認

Closes #91