### PR TITLE
fix: アプリ再起動後にカレンダーが最後の閲覧月を復元しない問題を修正

### DIFF
--- a/src/screens/CalendarScreen.tsx
+++ b/src/screens/CalendarScreen.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useEffect, useMemo, useState } from "react";
+﻿import React, { useEffect, useMemo, useRef, useState } from "react";
 import { SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -46,6 +46,20 @@ const CalendarScreen: React.FC<Props> = ({ navigation }) => {
   });
   const monthKeyValue = monthKey(anchorDate);
   const [showMonthPicker, setShowMonthPicker] = useState(false);
+
+  // useState の lazy initializer は user=null（AsyncStorage ロード前）で実行されるため
+  // lastViewedMonth が読めない。user が初めてロードされたタイミングで1度だけ補正する。
+  const hasRestoredMonthRef = useRef(false);
+  useEffect(() => {
+    if (hasRestoredMonthRef.current) return;
+    if (user === null) return;
+    hasRestoredMonthRef.current = true;
+    if (!user.settings.lastViewedMonth) return;
+    const normalized = normalizeToUtcDate(user.settings.lastViewedMonth);
+    if (!Number.isNaN(normalized.getTime())) {
+      setAnchorDate(new Date(normalized.getFullYear(), normalized.getMonth(), 1));
+    }
+  }, [user]);
   const MIN_DATE = useMemo(() => new Date(1900, 0, 1), []);
   const MAX_DATE = useMemo(() => new Date(2100, 11, 31), []);
 


### PR DESCRIPTION
## 原因

`useState` の lazy initializer はコンポーネントマウント時に1度だけ実行される。AsyncStorage からの読み込みが非同期のため、`user=null`（ロード前）の状態でマウントされると `lastViewedMonth` が読めず、デフォルトの今日にフォールバックしていた。その後 `user` がロードされても `useState` は再実行されない。

## 修正内容

**`src/screens/CalendarScreen.tsx`**

`useRef` でフラグを管理し、`user` が最初に `null → 非null` になったタイミング（AsyncStorage ロード完了後）で `anchorDate` を `lastViewedMonth` に補正する。

```tsx
const hasRestoredMonthRef = useRef(false);
useEffect(() => {
  if (hasRestoredMonthRef.current) return;  // 1度だけ実行
  if (user === null) return;                // まだロード中
  hasRestoredMonthRef.current = true;
  if (!user.settings.lastViewedMonth) return;
  const normalized = normalizeToUtcDate(user.settings.lastViewedMonth);
  if (!Number.isNaN(normalized.getTime())) {
    setAnchorDate(new Date(normalized.getFullYear(), normalized.getMonth(), 1));
  }
}, [user]);
```

プロフィール編集などによる `user` の変更では補正しない（`useRef` フラグで制御）。

## 確認手順

1. カレンダーで当月以外（例: 先月）を表示する
2. アプリをタスクキルで終了する
3. 再度アプリを起動し、カレンダー画面を確認
4. 最後に閲覧した月が表示されることを確認

Closes #115