### PR TITLE
fix: RecordDetailScreen の戻る処理を goBack() に変更 (#107)

### DIFF
--- a/__tests__/RecordDetailScreen.ui.jest.test.tsx
+++ b/__tests__/RecordDetailScreen.ui.jest.test.tsx
@@ -67,7 +67,7 @@ describe('RecordDetailScreen UI (TS-UI-006)', () => {
     expect(json).toContain('記録が見つかりません');
   });
 
-  test('from=list のとき「記録一覧に戻る」ボタンを表示', async () => {
+  test('from=list のとき「戻る」ボタンを表示', async () => {
     mockStore = {};
     const route = { params: { recordId: 'nonexistent', isoDate: '2024-06-01', from: 'list' } };
     const RecordDetailScreen = require('../src/screens/RecordDetailScreen').default;
@@ -78,7 +78,7 @@ describe('RecordDetailScreen UI (TS-UI-006)', () => {
       );
     });
     const json = JSON.stringify(tree.toJSON());
-    expect(json).toContain('記録一覧に戻る');
+    expect(json).toContain('戻る');
   });
 
   test('record あり: 記録詳細を表示', async () => {

--- a/src/screens/RecordDetailScreen.tsx
+++ b/src/screens/RecordDetailScreen.tsx
@@ -18,7 +18,7 @@ const RecordDetailScreen: React.FC<Props> = ({ navigation, route }) => {
   // 選択中ベビー名取得（ベビー名のない場合は "記録" のまま）
   const user = useActiveUser();
   const { recordId, isoDate, from } = route.params ?? {};
-  const { store } = useAchievements();
+  const { store, loading } = useAchievements();
   const [photoPath, setPhotoPath] = useState<string | null>(null);
 
   const record = useMemo(() => {
@@ -60,14 +60,14 @@ const RecordDetailScreen: React.FC<Props> = ({ navigation, route }) => {
   }, [record?.photoPath]);
 
   if (!record) {
-    const targetStack = from === "list" ? "RecordListStack" : "CalendarStack";
+    if (loading) return null;
     return (
       <SafeAreaView style={styles.safeArea}>
         <View style={styles.centered}>
           <Text style={styles.title}>記録が見つかりません</Text>
           <Button
-            title={from === "list" ? "記録一覧に戻る" : "今日に戻る"}
-            onPress={() => (navigation as any).replace("MainTabs", { screen: targetStack })}
+            title="戻る"
+            onPress={() => navigation.goBack()}
           />
         </View>
       </SafeAreaView>


### PR DESCRIPTION
## 修正内容

- `navigation.replace("MainTabs", { screen: targetStack })` を `navigation.goBack()` に変更
  - `replace("MainTabs", ...)` はRootStackに重複したMainTabsエントリを作成していたため、スワイプバックで誤ったナビゲーション状態が見えるバグの原因だった
- ロード中（`loading=true`）は `null` を返すガードを追加
  - AsyncStorageの読み込み完了前にrecordがnullになっても「記録が見つかりません」が誤表示されないよう対処

## 確認手順

1. 任意の記録詳細画面を開く
2. 記録一覧から記録詳細へ進む
3. 戻るボタンで正しく一覧に戻れることを確認
4. AchievementListScreen からのスワイプバックで TodayScreen が不正に表示されないことを確認

Closes #107