### PR TITLE
fix: AsyncStorageの平文保存をEncryptedStorageに切り替える

### DIFF
--- a/__tests__/photo.utils.jest.test.ts
+++ b/__tests__/photo.utils.jest.test.ts
@@ -67,6 +67,8 @@ describe('photo utils', () => {
     expect(result).toBe(arg.to);
   });
 
+  const SAFE_PATH = 'file:///doc/achievement-photos/x.jpg';
+
   test('ensureFileExistsAsync returns null for empty path', async () => {
     await expect(ensureFileExistsAsync(undefined)).resolves.toBeNull();
     await expect(ensureFileExistsAsync(null)).resolves.toBeNull();
@@ -75,15 +77,22 @@ describe('photo utils', () => {
 
   test('ensureFileExistsAsync returns null when file does not exist', async () => {
     (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({ exists: false });
-    await expect(ensureFileExistsAsync('/x.jpg')).resolves.toBeNull();
+    await expect(ensureFileExistsAsync(SAFE_PATH)).resolves.toBeNull();
   });
 
   test('ensureFileExistsAsync warns and returns null when fs check throws', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     (FileSystem.getInfoAsync as jest.Mock).mockRejectedValue(new Error('boom'));
 
-    await expect(ensureFileExistsAsync('/x.jpg')).resolves.toBeNull();
+    await expect(ensureFileExistsAsync(SAFE_PATH)).resolves.toBeNull();
     expect(warnSpy).toHaveBeenCalled();
+  });
+
+  test('ensureFileExistsAsync warns and returns null for unsafe path', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await expect(ensureFileExistsAsync('../../databases/RKStorage')).resolves.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith('Unsafe photoPath rejected:', '../../databases/RKStorage');
+    expect(FileSystem.getInfoAsync).not.toHaveBeenCalled();
   });
 
   test('deleteIfExistsAsync does nothing for empty path', async () => {
@@ -95,16 +104,24 @@ describe('photo utils', () => {
 
   test('deleteIfExistsAsync deletes when file exists', async () => {
     (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({ exists: true });
-    await deleteIfExistsAsync('/x.jpg');
-    expect(FileSystem.deleteAsync).toHaveBeenCalledWith('/x.jpg', { idempotent: true });
+    await deleteIfExistsAsync(SAFE_PATH);
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith(SAFE_PATH, { idempotent: true });
   });
 
   test('deleteIfExistsAsync warns when fs check throws', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     (FileSystem.getInfoAsync as jest.Mock).mockRejectedValue(new Error('nope'));
 
-    await expect(deleteIfExistsAsync('/x.jpg')).resolves.toBeUndefined();
+    await expect(deleteIfExistsAsync(SAFE_PATH)).resolves.toBeUndefined();
     expect(warnSpy).toHaveBeenCalled();
+  });
+
+  test('deleteIfExistsAsync warns and does nothing for unsafe path', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await deleteIfExistsAsync('../../databases/RKStorage');
+    expect(warnSpy).toHaveBeenCalledWith('Unsafe photoPath rejected:', '../../databases/RKStorage');
+    expect(FileSystem.getInfoAsync).not.toHaveBeenCalled();
+    expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
   });
 
   test('pickAndSavePhotoAsync uses empty resize actions when long edge is small and skips directory creation when exists', async () => {
@@ -165,13 +182,13 @@ describe('photo utils', () => {
   test('ensureFileExistsAsync returns original path when file exists', async () => {
     (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({ exists: true });
 
-    await expect(ensureFileExistsAsync('/exists.jpg')).resolves.toBe('/exists.jpg');
+    await expect(ensureFileExistsAsync(SAFE_PATH)).resolves.toBe(SAFE_PATH);
   });
 
   test('deleteIfExistsAsync skips delete when file does not exist', async () => {
     (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({ exists: false });
 
-    await deleteIfExistsAsync('/missing.jpg');
+    await deleteIfExistsAsync(SAFE_PATH);
     expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-encrypted-storage": "^4.0.3",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-get-random-values": "~1.11.0",
         "react-native-reanimated": "~4.1.1",
@@ -10966,6 +10967,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-encrypted-storage": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-encrypted-storage/-/react-native-encrypted-storage-4.0.3.tgz",
+      "integrity": "sha512-0pJA4Aj2S1PIJEbU7pN/Qvf7JIJx3hFywx+i+bLHtgK0/6Zryf1V2xVsWcrD50dfiu3jY1eN2gesQ5osGxE7jA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-gesture-handler": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-encrypted-storage": "^4.0.3",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-get-random-values": "~1.11.0",
     "react-native-reanimated": "~4.1.1",

--- a/src/state/AppStateContext.tsx
+++ b/src/state/AppStateContext.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
 } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import EncryptedStorage from "react-native-encrypted-storage";
 import { v4 as uuid } from "uuid";
 
 import { STORAGE_KEYS, loadAchievements, loadUserSettings } from "@/storage/storage";
@@ -82,7 +83,7 @@ const AppStateContext = createContext<AppStateContextValue | undefined>(undefine
 
 const persistState = async (nextState: AppState) => {
   try {
-    await AsyncStorage.setItem(APP_STATE_KEY, JSON.stringify(nextState));
+    await EncryptedStorage.setItem(APP_STATE_KEY, JSON.stringify(nextState));
   } catch (error) {
     console.warn("Failed to persist AppState", error);
   }
@@ -181,16 +182,30 @@ const migrateLegacyState = async (): Promise<AppState | null> => {
 };
 
 const loadAppState = async (): Promise<AppState> => {
-  const raw = await AsyncStorage.getItem(APP_STATE_KEY);
-  if (raw) {
+  // 1. 暗号化ストレージから読む（正常系）
+  const encryptedRaw = await EncryptedStorage.getItem(APP_STATE_KEY);
+  if (encryptedRaw) {
     try {
-      const parsed = JSON.parse(raw) as AppState;
-      return ensureStateIntegrity(parsed);
+      return ensureStateIntegrity(JSON.parse(encryptedRaw) as AppState);
     } catch (error) {
-      console.warn("Failed to parse AppState; resetting", error);
+      console.warn("Failed to parse encrypted AppState; falling through", error);
     }
   }
 
+  // 2. 平文AsyncStorageからの移行（既存ユーザー、一度だけ実行）
+  const plainRaw = await AsyncStorage.getItem(APP_STATE_KEY);
+  if (plainRaw) {
+    try {
+      const state = ensureStateIntegrity(JSON.parse(plainRaw) as AppState);
+      await persistState(state);
+      await AsyncStorage.removeItem(APP_STATE_KEY);
+      return state;
+    } catch (error) {
+      console.warn("Failed to migrate plain AppState; falling through", error);
+    }
+  }
+
+  // 3. レガシーキー（v1形式）からの移行
   const migrated = await migrateLegacyState();
   if (migrated) return ensureStateIntegrity(migrated);
 

--- a/src/utils/photo.ts
+++ b/src/utils/photo.ts
@@ -13,6 +13,8 @@ const PHOTO_DIR = `${FileSystem.documentDirectory}achievement-photos/`;
 const MAX_LONG_EDGE = 1600;
 const JPEG_QUALITY = 0.75;
 
+const isSafePhotoPath = (path: string): boolean => path.startsWith(PHOTO_DIR);
+
 const ensurePhotoDirAsync = async () => {
   const dirInfo = await FileSystem.getInfoAsync(PHOTO_DIR);
   if (!dirInfo.exists) {
@@ -89,6 +91,10 @@ export const pickAndSavePhotoAsync = async (): Promise<string | null> => {
  */
 export const ensureFileExistsAsync = async (path?: string | null): Promise<string | null> => {
   if (!path) return null;
+  if (!isSafePhotoPath(path)) {
+    console.warn("Unsafe photoPath rejected:", path);
+    return null;
+  }
   try {
     const info = await FileSystem.getInfoAsync(path);
     return info.exists ? path : null;
@@ -103,6 +109,10 @@ export const ensureFileExistsAsync = async (path?: string | null): Promise<strin
  */
 export const deleteIfExistsAsync = async (path?: string | null) => {
   if (!path) return;
+  if (!isSafePhotoPath(path)) {
+    console.warn("Unsafe photoPath rejected:", path);
+    return;
+  }
   try {
     const info = await FileSystem.getInfoAsync(path);
     if (info.exists) {


### PR DESCRIPTION
## 概要

Closes #151
Closes #152

AsyncStorageの平文保存を`react-native-encrypted-storage`による暗号化ストレージに切り替えました。

- iOS: Keychain
- Android: EncryptedSharedPreferences

また、`photoPath`をPHOTO_DIRプレフィックスで検証し、任意パス操作の脆弱性を修正しました。

## 変更内容

- `react-native-encrypted-storage` を依存に追加
- `persistState()`: `EncryptedStorage.setItem` に変更
- `loadAppState()`: 3段階フォールバックに変更
  1. EncryptedStorageから読む（正常系）
  2. AsyncStorage（平文）からの移行（既存ユーザー、一度だけ実行）→ 移行後に平文データを削除
  3. v1レガシーキーからの移行（既存処理を流用）
- `photoPath`の検証にPHOTO_DIRプレフィックスチェックを追加

## 確認手順

> **注意**: ネイティブモジュールのためExpo Goでは動作しません。EASビルドまたは実機での確認が必要です。

- [ ] 新規インストール: データ保存・読み込みが正常動作すること
- [ ] 既存ユーザー（平文データあり）: 起動後にデータが引き継がれ、平文キーが削除されること
- [ ] 不正なphotoPath（PHOTO_DIR外）が拒否されること