### PR TITLE
fix: photoPathの検証でパストラバーサル脆弱性を修正する

### DIFF
--- a/__tests__/photo.utils.jest.test.ts
+++ b/__tests__/photo.utils.jest.test.ts
@@ -67,6 +67,8 @@ describe('photo utils', () => {
     expect(result).toBe(arg.to);
   });
 
+  const SAFE_PATH = 'file:///doc/achievement-photos/x.jpg';
+
   test('ensureFileExistsAsync returns null for empty path', async () => {
     await expect(ensureFileExistsAsync(undefined)).resolves.toBeNull();
     await expect(ensureFileExistsAsync(null)).resolves.toBeNull();
@@ -75,15 +77,22 @@ describe('photo utils', () => {
 
   test('ensureFileExistsAsync returns null when file does not exist', async () => {
     (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({ exists: false });
-    await expect(ensureFileExistsAsync('/x.jpg')).resolves.toBeNull();
+    await expect(ensureFileExistsAsync(SAFE_PATH)).resolves.toBeNull();
   });
 
   test('ensureFileExistsAsync warns and returns null when fs check throws', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     (FileSystem.getInfoAsync as jest.Mock).mockRejectedValue(new Error('boom'));
 
-    await expect(ensureFileExistsAsync('/x.jpg')).resolves.toBeNull();
+    await expect(ensureFileExistsAsync(SAFE_PATH)).resolves.toBeNull();
     expect(warnSpy).toHaveBeenCalled();
+  });
+
+  test('ensureFileExistsAsync warns and returns null for unsafe path', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await expect(ensureFileExistsAsync('../../databases/RKStorage')).resolves.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith('Unsafe photoPath rejected:', '../../databases/RKStorage');
+    expect(FileSystem.getInfoAsync).not.toHaveBeenCalled();
   });
 
   test('deleteIfExistsAsync does nothing for empty path', async () => {
@@ -95,16 +104,24 @@ describe('photo utils', () => {
 
   test('deleteIfExistsAsync deletes when file exists', async () => {
     (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({ exists: true });
-    await deleteIfExistsAsync('/x.jpg');
-    expect(FileSystem.deleteAsync).toHaveBeenCalledWith('/x.jpg', { idempotent: true });
+    await deleteIfExistsAsync(SAFE_PATH);
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith(SAFE_PATH, { idempotent: true });
   });
 
   test('deleteIfExistsAsync warns when fs check throws', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     (FileSystem.getInfoAsync as jest.Mock).mockRejectedValue(new Error('nope'));
 
-    await expect(deleteIfExistsAsync('/x.jpg')).resolves.toBeUndefined();
+    await expect(deleteIfExistsAsync(SAFE_PATH)).resolves.toBeUndefined();
     expect(warnSpy).toHaveBeenCalled();
+  });
+
+  test('deleteIfExistsAsync warns and does nothing for unsafe path', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await deleteIfExistsAsync('../../databases/RKStorage');
+    expect(warnSpy).toHaveBeenCalledWith('Unsafe photoPath rejected:', '../../databases/RKStorage');
+    expect(FileSystem.getInfoAsync).not.toHaveBeenCalled();
+    expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
   });
 
   test('pickAndSavePhotoAsync uses empty resize actions when long edge is small and skips directory creation when exists', async () => {
@@ -165,13 +182,13 @@ describe('photo utils', () => {
   test('ensureFileExistsAsync returns original path when file exists', async () => {
     (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({ exists: true });
 
-    await expect(ensureFileExistsAsync('/exists.jpg')).resolves.toBe('/exists.jpg');
+    await expect(ensureFileExistsAsync(SAFE_PATH)).resolves.toBe(SAFE_PATH);
   });
 
   test('deleteIfExistsAsync skips delete when file does not exist', async () => {
     (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({ exists: false });
 
-    await deleteIfExistsAsync('/missing.jpg');
+    await deleteIfExistsAsync(SAFE_PATH);
     expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
   });
 

--- a/src/utils/photo.ts
+++ b/src/utils/photo.ts
@@ -13,6 +13,8 @@ const PHOTO_DIR = `${FileSystem.documentDirectory}achievement-photos/`;
 const MAX_LONG_EDGE = 1600;
 const JPEG_QUALITY = 0.75;
 
+const isSafePhotoPath = (path: string): boolean => path.startsWith(PHOTO_DIR);
+
 const ensurePhotoDirAsync = async () => {
   const dirInfo = await FileSystem.getInfoAsync(PHOTO_DIR);
   if (!dirInfo.exists) {
@@ -89,6 +91,10 @@ export const pickAndSavePhotoAsync = async (): Promise<string | null> => {
  */
 export const ensureFileExistsAsync = async (path?: string | null): Promise<string | null> => {
   if (!path) return null;
+  if (!isSafePhotoPath(path)) {
+    console.warn("Unsafe photoPath rejected:", path);
+    return null;
+  }
   try {
     const info = await FileSystem.getInfoAsync(path);
     return info.exists ? path : null;
@@ -103,6 +109,10 @@ export const ensureFileExistsAsync = async (path?: string | null): Promise<strin
  */
 export const deleteIfExistsAsync = async (path?: string | null) => {
   if (!path) return;
+  if (!isSafePhotoPath(path)) {
+    console.warn("Unsafe photoPath rejected:", path);
+    return;
+  }
   try {
     const info = await FileSystem.getInfoAsync(path);
     if (info.exists) {


### PR DESCRIPTION
## 概要

Closes #152

`photoPath` にPHOTO_DIRプレフィックス検証を追加し、任意パス操作（パストラバーサル）の脆弱性を修正しました。

## 変更内容

- `src/utils/photo.ts`: PHOTO_DIRプレフィックスチェックを追加
- `__tests__/photo.utils.jest.test.ts`: 検証ロジックのテストを追加

## 確認手順

- [ ] `npm run test:unit` がパスすること
- [ ] `npm run typecheck` がパスすること