### PR TITLE
fix: カレンダー画面の文言を整理する

### DIFF
--- a/src/components/MonthHeader.tsx
+++ b/src/components/MonthHeader.tsx
@@ -25,7 +25,6 @@ const MonthHeader: React.FC<Props> = ({
     <View style={styles.center}>
       <TouchableOpacity accessibilityRole="button" onPress={onPressMonthLabel} style={styles.monthButton}>
         <Text style={styles.month}>{monthLabel}</Text>
-        <Text style={styles.monthHint}>年月を選択</Text>
       </TouchableOpacity>
       <TouchableOpacity accessibilityRole="button" onPress={onToday}>
         <Text style={styles.today}>今日へ</Text>
@@ -67,10 +66,6 @@ const styles = StyleSheet.create({
     fontSize: 20,
     color: COLORS.textPrimary,
     fontWeight: "600",
-  },
-  monthHint: {
-    fontSize: 12,
-    color: COLORS.textSecondary,
   },
   today: {
     fontSize: 14,

--- a/src/screens/CalendarScreen.tsx
+++ b/src/screens/CalendarScreen.tsx
@@ -208,9 +208,8 @@ const CalendarScreen: React.FC<Props> = ({ navigation }) => {
             ))}
           </View>
           <CalendarGrid days={monthView.days} onPressDay={handlePressDay} />
-          <Text style={styles.footer}>予定日前は在胎表示です（修正月齢は表示しません）。</Text>
+          <Text style={styles.footer}>出産予定日前の修正月齢は在胎週数で表示しています。</Text>
           <Text style={styles.footer}>修正月齢の表記は目安です。医療的判断は主治医にご相談ください。</Text>
-          <Text style={styles.footer}>データは端末内で保存します。</Text>
         </View>
       </ScrollView>
       <TouchableOpacity


### PR DESCRIPTION
## 概要

Closes #155

カレンダー画面の不要な文言を削除・整理しました。

## 変更内容

- `MonthHeader.tsx`: 「年月を選択」ヒントテキストを削除
- `CalendarScreen.tsx`: 下部フッターを整理
  - 「予定日前は在胎表示です…」→「出産予定日前の修正月齢は在胎週数で表示しています。」に変更
  - 「データは端末内で保存します。」を削除

## 確認手順

- [ ] カレンダー画面を開き、月表示の下に「年月を選択」が表示されないこと
- [ ] 下部フッターが1行のみ（「出産予定日前の…」）と「修正月齢の表記は…」の2行になっていること