### PR TITLE
feat: 子どもプロフィールの登録上限を5人に設定する

### DIFF
--- a/__tests__/AppStateContext.jest.test.tsx
+++ b/__tests__/AppStateContext.jest.test.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import { Text } from 'react-native';
-import { act, render, waitFor } from '@testing-library/react-native';
+import React from "react";
+import { Text } from "react-native";
+import { act, render, waitFor } from "@testing-library/react-native";
 
 const mockGetItem = jest.fn();
 const mockSetItem = jest.fn();
 const mockRemoveItem = jest.fn();
 
-jest.mock('@react-native-async-storage/async-storage', () => ({
+jest.mock("@react-native-async-storage/async-storage", () => ({
   __esModule: true,
   default: {
     getItem: (...args: any[]) => mockGetItem(...args),
@@ -18,35 +18,36 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 const mockLoadUserSettings = jest.fn();
 const mockLoadAchievements = jest.fn();
 
-jest.mock('../src/storage/storage', () => ({
+jest.mock("../src/storage/storage", () => ({
   STORAGE_KEYS: {
-    userSettings: 'legacy_settings',
-    achievementStore: 'legacy_achievements',
+    userSettings: "legacy_settings",
+    achievementStore: "legacy_achievements",
   },
   loadUserSettings: (...args: any[]) => mockLoadUserSettings(...args),
   loadAchievements: (...args: any[]) => mockLoadAchievements(...args),
 }));
 
-jest.mock('uuid', () => ({
-  v4: jest.fn(() => 'uuid-fixed'),
+jest.mock("uuid", () => ({
+  v4: jest.fn(() => "uuid-fixed"),
 }));
 
 import {
   AppStateProvider,
+  MAX_PROFILES,
   useAppState,
   useAchievements,
   useActiveUser,
   UserSettings,
-} from '../src/state/AppStateContext';
+} from "../src/state/AppStateContext";
 
 const settings: UserSettings = {
   showCorrectedUntilMonths: 24,
-  ageFormat: 'ymd',
+  ageFormat: "ymd",
   showDaysSinceBirth: true,
   lastViewedMonth: null,
 };
 
-describe('AppStateContext', () => {
+describe("AppStateContext", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetItem.mockReset();
@@ -56,19 +57,30 @@ describe('AppStateContext', () => {
     mockLoadAchievements.mockReset();
   });
 
-  test('useAppState throws outside provider', () => {
+  test("useAppState throws outside provider", () => {
     const Probe = () => {
       useAppState();
       return <Text>ng</Text>;
     };
-    expect(() => render(<Probe />)).toThrow('useAppState must be used within AppStateProvider');
+    expect(() => render(<Probe />)).toThrow(
+      "useAppState must be used within AppStateProvider"
+    );
   });
 
-  test('initial load uses APP_STATE_KEY JSON and sets loading false', async () => {
+  test("initial load uses APP_STATE_KEY JSON and sets loading false", async () => {
     mockGetItem.mockResolvedValueOnce(
       JSON.stringify({
-        users: [{ id: 'u1', name: 'A', birthDate: '2025-01-01', dueDate: null, settings, createdAt: '2025-01-01T00:00:00.000Z' }],
-        activeUserId: 'u1',
+        users: [
+          {
+            id: "u1",
+            name: "A",
+            birthDate: "2025-01-01",
+            dueDate: null,
+            settings,
+            createdAt: "2025-01-01T00:00:00.000Z",
+          },
+        ],
+        activeUserId: "u1",
         achievements: { u1: [] },
       })
     );
@@ -79,15 +91,22 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
 
     await waitFor(() => expect(captured?.loading).toBe(false));
-    expect(captured!.state.activeUserId).toBe('u1');
+    expect(captured!.state.activeUserId).toBe("u1");
     expect(captured!.state.users).toHaveLength(1);
   });
 
-  test('addUser creates achievement list and sets active when null', async () => {
-    mockGetItem.mockResolvedValueOnce(null).mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+  test("addUser creates achievement list and sets active when null", async () => {
+    mockGetItem
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
 
     let captured: ReturnType<typeof useAppState> | null = null;
     const Probe = () => {
@@ -95,31 +114,49 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     await act(async () => {
       await captured!.addUser({
-        name: 'Baby',
-        birthDate: '2025-01-01',
+        name: "Baby",
+        birthDate: "2025-01-01",
         dueDate: null,
         settings,
       });
     });
 
-    expect(captured!.state.users.map((u) => u.id)).toContain('uuid-fixed');
-    expect(captured!.state.achievements['uuid-fixed']).toEqual([]);
-    expect(captured!.state.activeUserId).toBe('uuid-fixed');
+    expect(captured!.state.users.map((u) => u.id)).toContain("uuid-fixed");
+    expect(captured!.state.achievements["uuid-fixed"]).toEqual([]);
+    expect(captured!.state.activeUserId).toBe("uuid-fixed");
   });
 
-  test('setActiveUser ignores unknown user id', async () => {
+  test("setActiveUser ignores unknown user id", async () => {
     mockGetItem.mockResolvedValueOnce(
       JSON.stringify({
         users: [
-          { id: 'u1', name: 'A', birthDate: '2025-01-01', dueDate: null, settings, createdAt: 't' },
-          { id: 'u2', name: 'B', birthDate: '2025-01-02', dueDate: null, settings, createdAt: 't' },
+          {
+            id: "u1",
+            name: "A",
+            birthDate: "2025-01-01",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
+          {
+            id: "u2",
+            name: "B",
+            birthDate: "2025-01-02",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
         ],
-        activeUserId: 'u1',
+        activeUserId: "u1",
         achievements: { u1: [], u2: [] },
       })
     );
@@ -130,24 +167,42 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     await act(async () => {
-      await captured!.setActiveUser('missing');
+      await captured!.setActiveUser("missing");
     });
 
-    expect(captured!.state.activeUserId).toBe('u1');
+    expect(captured!.state.activeUserId).toBe("u1");
   });
 
-  test('deleteUser switches active to next user or null', async () => {
+  test("deleteUser switches active to next user or null", async () => {
     mockGetItem.mockResolvedValueOnce(
       JSON.stringify({
         users: [
-          { id: 'u1', name: 'A', birthDate: '2025-01-01', dueDate: null, settings, createdAt: 't' },
-          { id: 'u2', name: 'B', birthDate: '2025-01-02', dueDate: null, settings, createdAt: 't' },
+          {
+            id: "u1",
+            name: "A",
+            birthDate: "2025-01-01",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
+          {
+            id: "u2",
+            name: "B",
+            birthDate: "2025-01-02",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
         ],
-        activeUserId: 'u1',
+        activeUserId: "u1",
         achievements: { u1: [], u2: [] },
       })
     );
@@ -158,37 +213,47 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     await act(async () => {
-      await captured!.deleteUser('u1');
+      await captured!.deleteUser("u1");
     });
-    expect(captured!.state.activeUserId).toBe('u2');
+    expect(captured!.state.activeUserId).toBe("u2");
 
     await act(async () => {
-      await captured!.deleteUser('u2');
+      await captured!.deleteUser("u2");
     });
     expect(captured!.state.activeUserId).toBeNull();
   });
 
-  test('legacy migration loads old keys, removes legacy keys, persists app state', async () => {
+  test("legacy migration loads old keys, removes legacy keys, persists app state", async () => {
     mockGetItem
       .mockResolvedValueOnce(null) // APP_STATE_KEY
-      .mockResolvedValueOnce('{legacy-settings}')
-      .mockResolvedValueOnce('{legacy-achievements}');
+      .mockResolvedValueOnce("{legacy-settings}")
+      .mockResolvedValueOnce("{legacy-achievements}");
 
     mockLoadUserSettings.mockResolvedValue({
-      birthDate: '2025-01-01',
-      dueDate: '2025-02-01',
+      birthDate: "2025-01-01",
+      dueDate: "2025-02-01",
       showCorrectedUntilMonths: 12,
-      ageFormat: 'md',
+      ageFormat: "md",
       showDaysSinceBirth: false,
-      lastViewedMonth: '2025-01-01',
+      lastViewedMonth: "2025-01-01",
     });
     mockLoadAchievements.mockResolvedValue({
-      '2025-01-10': [
-        { id: 'a1', date: '2025-01-10', title: 'x', tag: 'did', createdAt: 'c1' },
+      "2025-01-10": [
+        {
+          id: "a1",
+          date: "2025-01-10",
+          title: "x",
+          tag: "did",
+          createdAt: "c1",
+        },
       ],
     });
 
@@ -198,47 +263,70 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
 
     await waitFor(() => expect(captured?.loading).toBe(false));
 
-    expect(mockRemoveItem).toHaveBeenCalledWith('legacy_settings');
-    expect(mockRemoveItem).toHaveBeenCalledWith('legacy_achievements');
+    expect(mockRemoveItem).toHaveBeenCalledWith("legacy_settings");
+    expect(mockRemoveItem).toHaveBeenCalledWith("legacy_achievements");
     expect(mockSetItem).toHaveBeenCalled();
-    expect(captured!.state.users[0].id).toBe('uuid-fixed');
-    expect(captured!.state.activeUserId).toBe('uuid-fixed');
-    expect(captured!.state.achievements['uuid-fixed'][0].category).toBe('growth');
+    expect(captured!.state.users[0].id).toBe("uuid-fixed");
+    expect(captured!.state.activeUserId).toBe("uuid-fixed");
+    expect(captured!.state.achievements["uuid-fixed"][0].category).toBe(
+      "growth"
+    );
   });
 
-  test('useActiveUser and useAchievements read derived values', async () => {
+  test("useActiveUser and useAchievements read derived values", async () => {
     mockGetItem.mockResolvedValueOnce(
       JSON.stringify({
-        users: [{ id: 'u1', name: 'A', birthDate: '2025-01-01', dueDate: null, settings, createdAt: 't' }],
-        activeUserId: 'u1',
-        achievements: { u1: [{ id: 'a1', date: '2025-01-10', title: 'x', createdAt: 't' }] },
+        users: [
+          {
+            id: "u1",
+            name: "A",
+            birthDate: "2025-01-01",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
+        ],
+        activeUserId: "u1",
+        achievements: {
+          u1: [{ id: "a1", date: "2025-01-10", title: "x", createdAt: "t" }],
+        },
       })
     );
 
-    let activeUserName = '';
+    let activeUserName = "";
     let achievementCount = -1;
 
     const Probe = () => {
       const user = useActiveUser();
       const achievements = useAchievements();
-      activeUserName = user?.name ?? '';
+      activeUserName = user?.name ?? "";
       achievementCount = achievements.length;
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(achievementCount).toBe(1));
-    expect(activeUserName).toBe('A');
+    expect(activeUserName).toBe("A");
   });
 
-  test('broken APP_STATE_KEY falls back to empty state', async () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  test("broken APP_STATE_KEY falls back to empty state", async () => {
+    const warnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
     mockGetItem
-      .mockResolvedValueOnce('{broken-json') // APP_STATE_KEY
+      .mockResolvedValueOnce("{broken-json") // APP_STATE_KEY
       .mockResolvedValueOnce(null) // legacy settings
       .mockResolvedValueOnce(null); // legacy achievements
 
@@ -248,19 +336,35 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     expect(captured!.state.users).toEqual([]);
     expect(captured!.state.activeUserId).toBeNull();
-    expect(warnSpy).toHaveBeenCalledWith('Failed to parse AppState; resetting', expect.any(Error));
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Failed to parse AppState; resetting",
+      expect.any(Error)
+    );
   });
 
-  test('ensureStateIntegrity fixes invalid active user and missing achievements map', async () => {
+  test("ensureStateIntegrity fixes invalid active user and missing achievements map", async () => {
     mockGetItem.mockResolvedValueOnce(
       JSON.stringify({
-        users: [{ id: 'u1', name: 'A', birthDate: '2025-01-01', dueDate: null, settings, createdAt: 't' }],
-        activeUserId: 'missing-user',
+        users: [
+          {
+            id: "u1",
+            name: "A",
+            birthDate: "2025-01-01",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
+        ],
+        activeUserId: "missing-user",
         achievements: {},
       })
     );
@@ -271,18 +375,31 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
-    expect(captured!.state.activeUserId).toBe('u1');
+    expect(captured!.state.activeUserId).toBe("u1");
     expect(captured!.state.achievements.u1).toEqual([]);
   });
 
-  test('updateUser merges nested settings and keeps id', async () => {
+  test("updateUser merges nested settings and keeps id", async () => {
     mockGetItem.mockResolvedValueOnce(
       JSON.stringify({
-        users: [{ id: 'u1', name: 'A', birthDate: '2025-01-01', dueDate: null, settings, createdAt: 't' }],
-        activeUserId: 'u1',
+        users: [
+          {
+            id: "u1",
+            name: "A",
+            birthDate: "2025-01-01",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
+        ],
+        activeUserId: "u1",
         achievements: { u1: [] },
       })
     );
@@ -293,26 +410,35 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     await act(async () => {
-      await captured!.updateUser('u1', {
-        name: 'Updated',
-        settings: { ageFormat: 'md' },
+      await captured!.updateUser("u1", {
+        name: "Updated",
+        settings: { ageFormat: "md" },
       });
     });
 
-    expect(captured!.state.users[0].id).toBe('u1');
-    expect(captured!.state.users[0].name).toBe('Updated');
-    expect(captured!.state.users[0].settings.ageFormat).toBe('md');
+    expect(captured!.state.users[0].id).toBe("u1");
+    expect(captured!.state.users[0].name).toBe("Updated");
+    expect(captured!.state.users[0].settings.ageFormat).toBe("md");
     expect(captured!.state.users[0].settings.showDaysSinceBirth).toBe(true);
   });
 
-  test('persist warning is emitted when AsyncStorage.setItem fails', async () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-    mockGetItem.mockResolvedValueOnce(null).mockResolvedValueOnce(null).mockResolvedValueOnce(null);
-    mockSetItem.mockRejectedValueOnce(new Error('persist-failure'));
+  test("persist warning is emitted when AsyncStorage.setItem fails", async () => {
+    const warnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    mockGetItem
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    mockSetItem.mockRejectedValueOnce(new Error("persist-failure"));
 
     let captured: ReturnType<typeof useAppState> | null = null;
     const Probe = () => {
@@ -320,33 +446,40 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     await act(async () => {
       await captured!.addUser({
-        name: 'Baby',
-        birthDate: '2025-01-01',
+        name: "Baby",
+        birthDate: "2025-01-01",
         dueDate: null,
         settings,
       });
     });
 
     await waitFor(() => {
-      expect(warnSpy).toHaveBeenCalledWith('Failed to persist AppState', expect.any(Error));
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Failed to persist AppState",
+        expect.any(Error)
+      );
     });
   });
 
-  test('legacy migration without settings keeps defaults and normalizes tried/unknown tags', async () => {
+  test("legacy migration without settings keeps defaults and normalizes tried/unknown tags", async () => {
     mockGetItem
       .mockResolvedValueOnce(null) // APP_STATE_KEY
       .mockResolvedValueOnce(null) // legacy settings
-      .mockResolvedValueOnce('{legacy-achievements}');
+      .mockResolvedValueOnce("{legacy-achievements}");
 
     mockLoadAchievements.mockResolvedValue({
-      '2025-01-10': [
-        { id: 'a1', date: '2025-01-10', title: 'x', tag: 'tried' },
-        { id: 'a2', date: '2025-01-11', title: 'y', tag: 'other' },
+      "2025-01-10": [
+        { id: "a1", date: "2025-01-10", title: "x", tag: "tried" },
+        { id: "a2", date: "2025-01-11", title: "y", tag: "other" },
       ],
     });
 
@@ -356,17 +489,25 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
-    expect(captured!.state.users[0].settings.ageFormat).toBe('ymd');
-    expect(captured!.state.achievements['uuid-fixed'][0].category).toBe('effort');
-    expect(captured!.state.achievements['uuid-fixed'][1].category).toBe('growth');
+    expect(captured!.state.users[0].settings.ageFormat).toBe("ymd");
+    expect(captured!.state.achievements["uuid-fixed"][0].category).toBe(
+      "effort"
+    );
+    expect(captured!.state.achievements["uuid-fixed"][1].category).toBe(
+      "growth"
+    );
   });
 
-  test('ensureStateIntegrity fills null users/achievements and useAchievements returns empty for missing active map', async () => {
+  test("ensureStateIntegrity fills null users/achievements and useAchievements returns empty for missing active map", async () => {
     mockGetItem.mockResolvedValueOnce(
-      JSON.stringify({ users: null, activeUserId: 'ghost', achievements: null })
+      JSON.stringify({ users: null, activeUserId: "ghost", achievements: null })
     );
 
     let captured: ReturnType<typeof useAppState> | null = null;
@@ -377,7 +518,11 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     expect(captured!.state.users).toEqual([]);
@@ -385,14 +530,28 @@ describe('AppStateContext', () => {
     expect(activeAchievements).toEqual([]);
   });
 
-  test('updateUser keeps non-target users unchanged', async () => {
+  test("updateUser keeps non-target users unchanged", async () => {
     mockGetItem.mockResolvedValueOnce(
       JSON.stringify({
         users: [
-          { id: 'u1', name: 'A', birthDate: '2025-01-01', dueDate: null, settings, createdAt: 't' },
-          { id: 'u2', name: 'B', birthDate: '2025-01-02', dueDate: null, settings, createdAt: 't' },
+          {
+            id: "u1",
+            name: "A",
+            birthDate: "2025-01-01",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
+          {
+            id: "u2",
+            name: "B",
+            birthDate: "2025-01-02",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
         ],
-        activeUserId: 'u1',
+        activeUserId: "u1",
         achievements: { u1: [], u2: [] },
       })
     );
@@ -403,21 +562,34 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     await act(async () => {
-      await captured!.updateUser('u1', { name: 'Updated' });
+      await captured!.updateUser("u1", { name: "Updated" });
     });
 
-    expect(captured!.state.users.find((u) => u.id === 'u2')?.name).toBe('B');
+    expect(captured!.state.users.find((u) => u.id === "u2")?.name).toBe("B");
   });
 
-  test('add/update/delete achievement handle missing user bucket via fallback branches', async () => {
+  test("add/update/delete achievement handle missing user bucket via fallback branches", async () => {
     mockGetItem.mockResolvedValueOnce(
       JSON.stringify({
-        users: [{ id: 'u1', name: 'A', birthDate: '2025-01-01', dueDate: null, settings, createdAt: 't' }],
-        activeUserId: 'u1',
+        users: [
+          {
+            id: "u1",
+            name: "A",
+            birthDate: "2025-01-01",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
+        ],
+        activeUserId: "u1",
         achievements: { u1: [] },
       })
     );
@@ -430,41 +602,45 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     await act(async () => {
-      await captured!.addAchievement('u2', {
-        id: 'a1',
-        date: '2025-01-10',
-        title: 'x',
-        createdAt: 't',
+      await captured!.addAchievement("u2", {
+        id: "a1",
+        date: "2025-01-10",
+        title: "x",
+        createdAt: "t",
       } as any);
     });
     expect(captured!.state.achievements.u2).toHaveLength(1);
 
     await act(async () => {
-      await captured!.updateAchievement('u2', 'a1', { title: 'updated' });
-      await captured!.deleteAchievement('u2', 'a1');
-      await captured!.deleteAchievement('u3', 'none');
+      await captured!.updateAchievement("u2", "a1", { title: "updated" });
+      await captured!.deleteAchievement("u2", "a1");
+      await captured!.deleteAchievement("u3", "none");
     });
 
     expect(captured!.state.achievements.u2).toEqual([]);
     expect(activeAchievements).toEqual([]);
   });
 
-  test('legacy migration with settings-only uses empty achievements fallback', async () => {
+  test("legacy migration with settings-only uses empty achievements fallback", async () => {
     mockGetItem
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce('{legacy-settings}')
+      .mockResolvedValueOnce("{legacy-settings}")
       .mockResolvedValueOnce(null);
     mockLoadUserSettings.mockResolvedValue({
-      birthDate: '2025-01-01',
+      birthDate: "2025-01-01",
       dueDate: null,
       showCorrectedUntilMonths: 18,
-      ageFormat: 'md',
+      ageFormat: "md",
       showDaysSinceBirth: false,
-      lastViewedMonth: '2025-01-01',
+      lastViewedMonth: "2025-01-01",
     });
 
     let captured: ReturnType<typeof useAppState> | null = null;
@@ -473,22 +649,26 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
-    expect(captured!.state.achievements['uuid-fixed']).toEqual([]);
+    expect(captured!.state.achievements["uuid-fixed"]).toEqual([]);
     expect(mockLoadAchievements).not.toHaveBeenCalled();
   });
 
-  test('legacy migration skips non-array lists and fills defaults for missing id/date/title', async () => {
+  test("legacy migration skips non-array lists and fills defaults for missing id/date/title", async () => {
     mockGetItem
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce('{legacy-settings}')
-      .mockResolvedValueOnce('{legacy-achievements}');
-    mockLoadUserSettings.mockResolvedValue({ birthDate: '2025-01-01' });
+      .mockResolvedValueOnce("{legacy-settings}")
+      .mockResolvedValueOnce("{legacy-achievements}");
+    mockLoadUserSettings.mockResolvedValue({ birthDate: "2025-01-01" });
     mockLoadAchievements.mockResolvedValue({
-      '2025-01-10': { bad: true },
-      '2025-01-11': [{}],
+      "2025-01-10": { bad: true },
+      "2025-01-11": [{}],
     });
 
     let captured: ReturnType<typeof useAppState> | null = null;
@@ -497,25 +677,46 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
-    const list = captured!.state.achievements['uuid-fixed'];
+    const list = captured!.state.achievements["uuid-fixed"];
     expect(list).toHaveLength(1);
-    expect(list[0].id).toBe('uuid-fixed');
-    expect(list[0].date).toBe('');
-    expect(list[0].title).toBe('');
+    expect(list[0].id).toBe("uuid-fixed");
+    expect(list[0].date).toBe("");
+    expect(list[0].title).toBe("");
   });
 
-  test('deleteUser keeps active user when deleting non-active user and updateAchievement keeps list when id not found', async () => {
+  test("deleteUser keeps active user when deleting non-active user and updateAchievement keeps list when id not found", async () => {
     mockGetItem.mockResolvedValueOnce(
       JSON.stringify({
         users: [
-          { id: 'u1', name: 'A', birthDate: '2025-01-01', dueDate: null, settings, createdAt: 't' },
-          { id: 'u2', name: 'B', birthDate: '2025-01-02', dueDate: null, settings, createdAt: 't' },
+          {
+            id: "u1",
+            name: "A",
+            birthDate: "2025-01-01",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
+          {
+            id: "u2",
+            name: "B",
+            birthDate: "2025-01-02",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
         ],
-        activeUserId: 'u1',
-        achievements: { u1: [{ id: 'a1', date: '2025-01-10', title: 'x', createdAt: 't' }], u2: [] },
+        activeUserId: "u1",
+        achievements: {
+          u1: [{ id: "a1", date: "2025-01-10", title: "x", createdAt: "t" }],
+          u2: [],
+        },
       })
     );
 
@@ -527,28 +728,41 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     await act(async () => {
-      await captured!.deleteUser('u2');
-      await captured!.updateAchievement('u1', 'missing', { title: 'ignored' });
-      await captured!.deleteAchievement('u1', 'missing');
-      await captured!.setActiveUser('u2');
+      await captured!.deleteUser("u2");
+      await captured!.updateAchievement("u1", "missing", { title: "ignored" });
+      await captured!.deleteAchievement("u1", "missing");
+      await captured!.setActiveUser("u2");
     });
 
-    expect(captured!.state.activeUserId).toBe('u1');
+    expect(captured!.state.activeUserId).toBe("u1");
     expect(captured!.state.achievements.u1).toHaveLength(1);
     expect(activeAchievements).toHaveLength(1);
 
-    expect(captured!.state.activeUserId).toBe('u1');
+    expect(captured!.state.activeUserId).toBe("u1");
   });
 
-  test('updateAchievement creates empty bucket when user achievements are missing', async () => {
+  test("updateAchievement creates empty bucket when user achievements are missing", async () => {
     mockGetItem.mockResolvedValueOnce(
       JSON.stringify({
-        users: [{ id: 'u1', name: 'A', birthDate: '2025-01-01', dueDate: null, settings, createdAt: 't' }],
-        activeUserId: 'u1',
+        users: [
+          {
+            id: "u1",
+            name: "A",
+            birthDate: "2025-01-01",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
+        ],
+        activeUserId: "u1",
         achievements: { u1: [] },
       })
     );
@@ -559,21 +773,116 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     await act(async () => {
-      await captured!.updateAchievement('u-missing', 'x', { title: 'noop' });
+      await captured!.updateAchievement("u-missing", "x", { title: "noop" });
     });
 
-    expect(captured!.state.achievements['u-missing']).toEqual([]);
+    expect(captured!.state.achievements["u-missing"]).toEqual([]);
   });
 
-  test('useAchievements returns empty when active user points to missing bucket', async () => {
+  test("addUser: 5人目まで登録できる", async () => {
+    mockGetItem
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    let captured: ReturnType<typeof useAppState> | null = null;
+    const Probe = () => {
+      captured = useAppState();
+      return <Text>ok</Text>;
+    };
+
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
+    await waitFor(() => expect(captured?.loading).toBe(false));
+
+    for (let i = 1; i <= MAX_PROFILES; i++) {
+      await act(async () => {
+        await captured!.addUser({
+          name: `Baby${i}`,
+          birthDate: "2025-01-01",
+          dueDate: null,
+          settings,
+          id: `u${i}`,
+        });
+      });
+    }
+
+    expect(captured!.state.users).toHaveLength(MAX_PROFILES);
+  });
+
+  test("addUser: 上限(5人)を超える登録は無視される", async () => {
+    const initialUsers = Array.from({ length: MAX_PROFILES }, (_, i) => ({
+      id: `u${i + 1}`,
+      name: `Baby${i + 1}`,
+      birthDate: "2025-01-01",
+      dueDate: null,
+      settings,
+      createdAt: "t",
+    }));
+    const initialAchievements = Object.fromEntries(
+      initialUsers.map((u) => [u.id, []])
+    );
+
     mockGetItem.mockResolvedValueOnce(
       JSON.stringify({
-        users: [{ id: 'u1', name: 'A', birthDate: '2025-01-01', dueDate: null, settings, createdAt: 't' }],
-        activeUserId: 'u1',
+        users: initialUsers,
+        activeUserId: "u1",
+        achievements: initialAchievements,
+      })
+    );
+
+    let captured: ReturnType<typeof useAppState> | null = null;
+    const Probe = () => {
+      captured = useAppState();
+      return <Text>ok</Text>;
+    };
+
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
+    await waitFor(() => expect(captured?.loading).toBe(false));
+
+    await act(async () => {
+      await captured!.addUser({
+        name: "Baby6",
+        birthDate: "2025-01-01",
+        dueDate: null,
+        settings,
+        id: "u6",
+      });
+    });
+
+    expect(captured!.state.users).toHaveLength(MAX_PROFILES);
+    expect(captured!.state.users.find((u) => u.id === "u6")).toBeUndefined();
+  });
+
+  test("useAchievements returns empty when active user points to missing bucket", async () => {
+    mockGetItem.mockResolvedValueOnce(
+      JSON.stringify({
+        users: [
+          {
+            id: "u1",
+            name: "A",
+            birthDate: "2025-01-01",
+            dueDate: null,
+            settings,
+            createdAt: "t",
+          },
+        ],
+        activeUserId: "u1",
         achievements: { u1: [] },
       })
     );
@@ -586,20 +895,35 @@ describe('AppStateContext', () => {
       return <Text>ok</Text>;
     };
 
-    render(<AppStateProvider><Probe /></AppStateProvider>);
+    render(
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    );
     await waitFor(() => expect(captured?.loading).toBe(false));
 
     await act(async () => {
-      await captured!.addUser({ name: 'B', birthDate: '2025-01-02', dueDate: null, settings, id: 'u2' });
-      await captured!.setActiveUser('u2');
-      await captured!.deleteAchievement('u2', 'none');
-      await captured!.setActiveUser('u1');
-      await captured!.deleteUser('u1');
-      await captured!.addUser({ name: 'C', birthDate: '2025-01-03', dueDate: null, settings, id: 'u3' });
-      await captured!.setActiveUser('u3');
+      await captured!.addUser({
+        name: "B",
+        birthDate: "2025-01-02",
+        dueDate: null,
+        settings,
+        id: "u2",
+      });
+      await captured!.setActiveUser("u2");
+      await captured!.deleteAchievement("u2", "none");
+      await captured!.setActiveUser("u1");
+      await captured!.deleteUser("u1");
+      await captured!.addUser({
+        name: "C",
+        birthDate: "2025-01-03",
+        dueDate: null,
+        settings,
+        id: "u3",
+      });
+      await captured!.setActiveUser("u3");
     });
 
     expect(achievements).toEqual([]);
   });
-
 });

--- a/__tests__/ProfileManagerScreen.ui.jest.test.tsx
+++ b/__tests__/ProfileManagerScreen.ui.jest.test.tsx
@@ -1,23 +1,25 @@
-import React from 'react';
-import renderer, { act } from 'react-test-renderer';
+import React from "react";
+import renderer, { act } from "react-test-renderer";
 
 let mockAppState: any = { users: [], activeUserId: null };
 
-jest.mock('@expo/vector-icons', () => ({
+jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
 }));
 
-jest.mock('@/components/AppText', () => {
-  const React = require('react');
-  const { Text } = require('react-native');
+jest.mock("@/components/AppText", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
   return {
     __esModule: true,
-    default: ({ children, style }: any) => React.createElement(Text, { style }, children),
+    default: ({ children, style }: any) =>
+      React.createElement(Text, { style }, children),
   };
 });
 
-jest.mock('@/state/AppStateContext', () => ({
+jest.mock("@/state/AppStateContext", () => ({
   useAppState: () => ({ state: mockAppState }),
+  MAX_PROFILES: 5,
 }));
 
 const mockNavigation = {
@@ -27,115 +29,216 @@ const mockNavigation = {
 };
 const mockRoute = { params: {} };
 
-describe('ProfileManagerScreen UI (TS-UI-010)', () => {
+describe("ProfileManagerScreen UI (TS-UI-010)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockNavigation.getParent.mockReturnValue({ setOptions: jest.fn() });
   });
 
-  test('users なし: ガイドテキストと追加ボタンを表示', async () => {
+  test("users なし: ガイドテキストと追加ボタンを表示", async () => {
     mockAppState = { users: [], activeUserId: null };
-    const ProfileManagerScreen = require('../src/screens/ProfileManagerScreen').default;
+    const ProfileManagerScreen =
+      require("../src/screens/ProfileManagerScreen").default;
     let tree: any;
     await act(async () => {
       tree = renderer.create(
-        React.createElement(ProfileManagerScreen, { navigation: mockNavigation, route: mockRoute })
+        React.createElement(ProfileManagerScreen, {
+          navigation: mockNavigation,
+          route: mockRoute,
+        })
       );
     });
     const json = JSON.stringify(tree.toJSON());
-    expect(json).toContain('新しいこどもを追加');
-    expect(json).toContain('編集したいこどもを選んでください');
+    expect(json).toContain("新しいこどもを追加");
+    expect(json).toContain("編集したいこどもを選んでください");
   });
 
-  test('users あり: ユーザーカードを表示', async () => {
+  test("users あり: ユーザーカードを表示", async () => {
     mockAppState = {
       users: [
         {
-          id: 'u1',
-          name: 'テストちゃん',
-          birthDate: '2024-01-01',
-          dueDate: '2024-02-15',
+          id: "u1",
+          name: "テストちゃん",
+          birthDate: "2024-01-01",
+          dueDate: "2024-02-15",
           settings: {
             showCorrectedUntilMonths: 24,
-            ageFormat: 'ymd',
+            ageFormat: "ymd",
             showDaysSinceBirth: true,
             lastViewedMonth: null,
           },
         },
       ],
-      activeUserId: 'u1',
+      activeUserId: "u1",
     };
-    const ProfileManagerScreen = require('../src/screens/ProfileManagerScreen').default;
+    const ProfileManagerScreen =
+      require("../src/screens/ProfileManagerScreen").default;
     let tree: any;
     await act(async () => {
       tree = renderer.create(
-        React.createElement(ProfileManagerScreen, { navigation: mockNavigation, route: mockRoute })
+        React.createElement(ProfileManagerScreen, {
+          navigation: mockNavigation,
+          route: mockRoute,
+        })
       );
     });
     const json = JSON.stringify(tree.toJSON());
-    expect(json).toContain('テストちゃん');
-    expect(json).toContain('2024-01-01');
-    expect(json).toContain('編集');
+    expect(json).toContain("テストちゃん");
+    expect(json).toContain("2024-01-01");
+    expect(json).toContain("編集");
   });
 
-  test('dueDate なし: なしを表示', async () => {
+  test("dueDate なし: なしを表示", async () => {
     mockAppState = {
       users: [
         {
-          id: 'u1',
-          name: 'テストちゃん',
-          birthDate: '2024-01-01',
+          id: "u1",
+          name: "テストちゃん",
+          birthDate: "2024-01-01",
           dueDate: null,
           settings: {
             showCorrectedUntilMonths: 24,
-            ageFormat: 'ymd',
+            ageFormat: "ymd",
             showDaysSinceBirth: true,
             lastViewedMonth: null,
           },
         },
       ],
-      activeUserId: 'u1',
+      activeUserId: "u1",
     };
-    const ProfileManagerScreen = require('../src/screens/ProfileManagerScreen').default;
+    const ProfileManagerScreen =
+      require("../src/screens/ProfileManagerScreen").default;
     let tree: any;
     await act(async () => {
       tree = renderer.create(
-        React.createElement(ProfileManagerScreen, { navigation: mockNavigation, route: mockRoute })
+        React.createElement(ProfileManagerScreen, {
+          navigation: mockNavigation,
+          route: mockRoute,
+        })
       );
     });
     const json = JSON.stringify(tree.toJSON());
-    expect(json).toContain('なし');
+    expect(json).toContain("なし");
   });
 
-  test('複数ユーザー: 全ユーザーのカードを表示', async () => {
+  test("5人登録済み: 追加ボタンがグレーアウトされる", async () => {
+    mockAppState = {
+      users: Array.from({ length: 5 }, (_, i) => ({
+        id: `u${i + 1}`,
+        name: `ちゃん${i + 1}`,
+        birthDate: "2024-01-01",
+        dueDate: null,
+        settings: {
+          showCorrectedUntilMonths: 24,
+          ageFormat: "ymd",
+          showDaysSinceBirth: true,
+          lastViewedMonth: null,
+        },
+      })),
+      activeUserId: "u1",
+    };
+    const ProfileManagerScreen =
+      require("../src/screens/ProfileManagerScreen").default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(ProfileManagerScreen, {
+          navigation: mockNavigation,
+          route: mockRoute,
+        })
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('"opacity":0.4');
+  });
+
+  test("5人登録済み: 追加ボタンタップでアラートを表示", async () => {
+    const alertSpy = jest.spyOn(require("react-native").Alert, "alert");
+    mockAppState = {
+      users: Array.from({ length: 5 }, (_, i) => ({
+        id: `u${i + 1}`,
+        name: `ちゃん${i + 1}`,
+        birthDate: "2024-01-01",
+        dueDate: null,
+        settings: {
+          showCorrectedUntilMonths: 24,
+          ageFormat: "ymd",
+          showDaysSinceBirth: true,
+          lastViewedMonth: null,
+        },
+      })),
+      activeUserId: "u1",
+    };
+    const ProfileManagerScreen =
+      require("../src/screens/ProfileManagerScreen").default;
+    let tree: any;
+    await act(async () => {
+      tree = renderer.create(
+        React.createElement(ProfileManagerScreen, {
+          navigation: mockNavigation,
+          route: mockRoute,
+        })
+      );
+    });
+
+    const buttons = tree.root.findAllByType(
+      require("react-native").TouchableOpacity
+    );
+    const addButton = buttons[buttons.length - 1];
+    await act(async () => {
+      addButton.props.onPress();
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      "",
+      "子どもは最大5人まで登録できます"
+    );
+    expect(mockNavigation.navigate).not.toHaveBeenCalled();
+  });
+
+  test("複数ユーザー: 全ユーザーのカードを表示", async () => {
     mockAppState = {
       users: [
         {
-          id: 'u1',
-          name: 'ちゃん1',
-          birthDate: '2024-01-01',
+          id: "u1",
+          name: "ちゃん1",
+          birthDate: "2024-01-01",
           dueDate: null,
-          settings: { showCorrectedUntilMonths: 24, ageFormat: 'ymd', showDaysSinceBirth: true, lastViewedMonth: null },
+          settings: {
+            showCorrectedUntilMonths: 24,
+            ageFormat: "ymd",
+            showDaysSinceBirth: true,
+            lastViewedMonth: null,
+          },
         },
         {
-          id: 'u2',
-          name: 'ちゃん2',
-          birthDate: '2023-05-10',
+          id: "u2",
+          name: "ちゃん2",
+          birthDate: "2023-05-10",
           dueDate: null,
-          settings: { showCorrectedUntilMonths: 24, ageFormat: 'ymd', showDaysSinceBirth: true, lastViewedMonth: null },
+          settings: {
+            showCorrectedUntilMonths: 24,
+            ageFormat: "ymd",
+            showDaysSinceBirth: true,
+            lastViewedMonth: null,
+          },
         },
       ],
-      activeUserId: 'u1',
+      activeUserId: "u1",
     };
-    const ProfileManagerScreen = require('../src/screens/ProfileManagerScreen').default;
+    const ProfileManagerScreen =
+      require("../src/screens/ProfileManagerScreen").default;
     let tree: any;
     await act(async () => {
       tree = renderer.create(
-        React.createElement(ProfileManagerScreen, { navigation: mockNavigation, route: mockRoute })
+        React.createElement(ProfileManagerScreen, {
+          navigation: mockNavigation,
+          route: mockRoute,
+        })
       );
     });
     const json = JSON.stringify(tree.toJSON());
-    expect(json).toContain('ちゃん1');
-    expect(json).toContain('ちゃん2');
+    expect(json).toContain("ちゃん1");
+    expect(json).toContain("ちゃん2");
   });
 });

--- a/src/screens/ProfileManagerScreen.tsx
+++ b/src/screens/ProfileManagerScreen.tsx
@@ -1,12 +1,20 @@
 ﻿import React, { useLayoutEffect } from "react";
-import { SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import {
+  Alert,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Ionicons } from "@expo/vector-icons";
 
 import { SettingsStackParamList } from "@/navigation";
 import AppText from "@/components/AppText";
-import { useAppState } from "@/state/AppStateContext";
+import { MAX_PROFILES, useAppState } from "@/state/AppStateContext";
 import { COLORS } from "@/constants/colors";
 
 type Props = NativeStackScreenProps<SettingsStackParamList, "ProfileManager">;
@@ -14,6 +22,7 @@ type Props = NativeStackScreenProps<SettingsStackParamList, "ProfileManager">;
 const ProfileManagerScreen: React.FC<Props> = ({ navigation }) => {
   const { state } = useAppState();
   const { users } = state;
+  const isAtLimit = users.length >= MAX_PROFILES;
 
   useLayoutEffect(() => {
     const parent = navigation.getParent();
@@ -49,11 +58,15 @@ const ProfileManagerScreen: React.FC<Props> = ({ navigation }) => {
               <View style={styles.cardInfo}>
                 <Text style={styles.cardName}>{user.name || "名前未設定"}</Text>
                 <Text style={styles.cardMeta}>誕生日: {user.birthDate}</Text>
-                <Text style={styles.cardMeta}>予定日: {user.dueDate ?? "なし"}</Text>
+                <Text style={styles.cardMeta}>
+                  予定日: {user.dueDate ?? "なし"}
+                </Text>
               </View>
               <TouchableOpacity
                 style={styles.editButton}
-                onPress={() => navigation.navigate("ProfileEdit", { profileId: user.id })}
+                onPress={() =>
+                  navigation.navigate("ProfileEdit", { profileId: user.id })
+                }
                 accessibilityRole="button"
               >
                 <Text style={styles.editButtonText}>編集</Text>
@@ -64,11 +77,24 @@ const ProfileManagerScreen: React.FC<Props> = ({ navigation }) => {
 
         <View style={styles.footer}>
           <TouchableOpacity
-            style={styles.addButton}
-            onPress={() => navigation.navigate("ProfileEdit")}
+            style={[styles.addButton, isAtLimit && styles.addButtonDisabled]}
+            onPress={() => {
+              if (isAtLimit) {
+                Alert.alert("", "子どもは最大5人まで登録できます");
+                return;
+              }
+              navigation.navigate("ProfileEdit");
+            }}
             accessibilityRole="button"
           >
-            <Text style={styles.addButtonText}>＋ 新しいこどもを追加</Text>
+            <Text
+              style={[
+                styles.addButtonText,
+                isAtLimit && styles.addButtonTextDisabled,
+              ]}
+            >
+              ＋ 新しいこどもを追加
+            </Text>
           </TouchableOpacity>
         </View>
       </ScrollView>
@@ -165,6 +191,12 @@ const styles = StyleSheet.create({
     color: COLORS.textPrimary,
     fontSize: 16,
     fontWeight: "700",
+  },
+  addButtonDisabled: {
+    opacity: 0.4,
+  },
+  addButtonTextDisabled: {
+    color: COLORS.textSecondary,
   },
 });
 

--- a/src/state/AppStateContext.tsx
+++ b/src/state/AppStateContext.tsx
@@ -10,7 +10,11 @@ import React, {
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { v4 as uuid } from "uuid";
 
-import { STORAGE_KEYS, loadAchievements, loadUserSettings } from "@/storage/storage";
+import {
+  STORAGE_KEYS,
+  loadAchievements,
+  loadUserSettings,
+} from "@/storage/storage";
 
 export type UserSettings = {
   showCorrectedUntilMonths: number | null;
@@ -57,7 +61,9 @@ type AppStateContextValue = {
   addUser: (input: NewUserInput) => Promise<void>;
   updateUser: (
     userId: string,
-    partial: Partial<Omit<UserProfile, "id" | "settings">> & { settings?: Partial<UserSettings> }
+    partial: Partial<Omit<UserProfile, "id" | "settings">> & {
+      settings?: Partial<UserSettings>;
+    }
   ) => Promise<void>;
   deleteUser: (userId: string) => Promise<void>;
   setActiveUser: (userId: string) => Promise<void>;
@@ -70,6 +76,8 @@ type AppStateContextValue = {
   deleteAchievement: (userId: string, id: string) => Promise<void>;
 };
 
+export const MAX_PROFILES = 5;
+
 const APP_STATE_KEY = "little_baby_calendar_app_state";
 
 const EMPTY_STATE: AppState = {
@@ -78,7 +86,9 @@ const EMPTY_STATE: AppState = {
   achievements: {},
 };
 
-const AppStateContext = createContext<AppStateContextValue | undefined>(undefined);
+const AppStateContext = createContext<AppStateContextValue | undefined>(
+  undefined
+);
 
 const persistState = async (nextState: AppState) => {
   try {
@@ -115,20 +125,27 @@ const ensureStateIntegrity = (state: AppState): AppState => {
     if (!nextState.achievements[user.id]) {
       nextState.achievements[user.id] = [];
     }
-    nextState.achievements[user.id] = nextState.achievements[user.id].map(normalizeAchievement);
+    nextState.achievements[user.id] =
+      nextState.achievements[user.id].map(normalizeAchievement);
   });
 
   return nextState;
 };
 
 const migrateLegacyState = async (): Promise<AppState | null> => {
-  const legacySettingsRaw = await AsyncStorage.getItem(STORAGE_KEYS.userSettings);
-  const legacyAchievementsRaw = await AsyncStorage.getItem(STORAGE_KEYS.achievementStore);
+  const legacySettingsRaw = await AsyncStorage.getItem(
+    STORAGE_KEYS.userSettings
+  );
+  const legacyAchievementsRaw = await AsyncStorage.getItem(
+    STORAGE_KEYS.achievementStore
+  );
 
   if (!legacySettingsRaw && !legacyAchievementsRaw) return null;
 
   const legacySettings = legacySettingsRaw ? await loadUserSettings() : null;
-  const legacyAchievements = legacyAchievementsRaw ? await loadAchievements() : {};
+  const legacyAchievements = legacyAchievementsRaw
+    ? await loadAchievements()
+    : {};
 
   const userId = uuid();
   const now = new Date().toISOString();
@@ -136,7 +153,8 @@ const migrateLegacyState = async (): Promise<AppState | null> => {
   const profile: UserProfile = {
     id: userId,
     name: "Baby",
-    birthDate: legacySettings?.birthDate || new Date().toISOString().slice(0, 10),
+    birthDate:
+      legacySettings?.birthDate || new Date().toISOString().slice(0, 10),
     dueDate: legacySettings?.dueDate ?? null,
     settings: {
       showCorrectedUntilMonths: legacySettings?.showCorrectedUntilMonths ?? 24,
@@ -152,7 +170,12 @@ const migrateLegacyState = async (): Promise<AppState | null> => {
     if (!Array.isArray(list)) return;
     list.forEach((item) => {
       const legacyTag = (item as any).tag;
-      const tag = legacyTag === "did" ? "growth" : legacyTag === "tried" ? "effort" : "growth";
+      const tag =
+        legacyTag === "did"
+          ? "growth"
+          : legacyTag === "tried"
+            ? "effort"
+            : "growth";
       migratedAchievements.push({
         id: (item as any).id ?? uuid(),
         date: (item as any).date ?? "",
@@ -212,17 +235,21 @@ export const AppStateProvider: React.FC<{ children: React.ReactNode }> = ({
     void bootstrap();
   }, []);
 
-  const updateState = useCallback(async (updater: (prev: AppState) => AppState) => {
-    setState((prev) => {
-      const next = ensureStateIntegrity(updater(prev));
-      void persistState(next);
-      return next;
-    });
-  }, []);
+  const updateState = useCallback(
+    async (updater: (prev: AppState) => AppState) => {
+      setState((prev) => {
+        const next = ensureStateIntegrity(updater(prev));
+        void persistState(next);
+        return next;
+      });
+    },
+    []
+  );
 
   const addUser = useCallback(
     async (input: NewUserInput) => {
       await updateState((prev) => {
+        if (prev.users.length >= MAX_PROFILES) return prev;
         const userId = input.id ?? uuid();
         const createdAt = input.createdAt ?? new Date().toISOString();
         const profile: UserProfile = {
@@ -249,7 +276,12 @@ export const AppStateProvider: React.FC<{ children: React.ReactNode }> = ({
   );
 
   const updateUser = useCallback(
-    async (userId: string, partial: Partial<Omit<UserProfile, "id" | "settings">> & { settings?: Partial<UserSettings> }) => {
+    async (
+      userId: string,
+      partial: Partial<Omit<UserProfile, "id" | "settings">> & {
+        settings?: Partial<UserSettings>;
+      }
+    ) => {
       await updateState((prev) => {
         const nextUsers = prev.users.map((user) =>
           user.id === userId
@@ -360,10 +392,24 @@ export const AppStateProvider: React.FC<{ children: React.ReactNode }> = ({
       updateAchievement,
       deleteAchievement,
     }),
-    [state, loading, addUser, updateUser, deleteUser, setActiveUser, addAchievement, updateAchievement, deleteAchievement]
+    [
+      state,
+      loading,
+      addUser,
+      updateUser,
+      deleteUser,
+      setActiveUser,
+      addAchievement,
+      updateAchievement,
+      deleteAchievement,
+    ]
   );
 
-  return <AppStateContext.Provider value={value}>{children}</AppStateContext.Provider>;
+  return (
+    <AppStateContext.Provider value={value}>
+      {children}
+    </AppStateContext.Provider>
+  );
 };
 
 export const useAppState = (): AppStateContextValue => {

--- a/src/state/AppStateContext.tsx
+++ b/src/state/AppStateContext.tsx
@@ -80,6 +80,8 @@ type AppStateContextValue = {
   ) => Promise<void>;
 };
 
+export const MAX_PROFILES = 5;
+
 const APP_STATE_KEY = "little_baby_calendar_app_state";
 
 const EMPTY_STATE: AppState = {
@@ -251,6 +253,7 @@ export const AppStateProvider: React.FC<{ children: React.ReactNode }> = ({
   const addUser = useCallback(
     async (input: NewUserInput) => {
       await updateState((prev) => {
+        if (prev.users.length >= MAX_PROFILES) return prev;
         const userId = input.id ?? uuid();
         const createdAt = input.createdAt ?? new Date().toISOString();
         const profile: UserProfile = {


### PR DESCRIPTION
## 概要

Closes #170

子どもプロフィールの登録数を最大5人に制限する。

## 変更内容

- `AppStateContext`: `MAX_PROFILES = 5` 定数を追加・エクスポート
- `AppStateContext`: `addUser()` に上限ガードを追加（上限時は state を変更せず返す）
- `ProfileManagerScreen`: 上限到達時に追加ボタンをグレーアウト（opacity: 0.4）
- `ProfileManagerScreen`: 上限時のボタンタップで `Alert.alert("", "子どもは最大5人まで登録できます")` を表示

## 確認手順

1. アプリ起動 → 設定 → プロフィール編集
2. 子どもを5人登録する → 5人目まで正常に追加できること
3. 5人登録後、追加ボタンがグレーアウトされること
4. グレーアウトされたボタンをタップ → アラート「子どもは最大5人まで登録できます」が表示されること
5. アラートを閉じた後、プロフィール一覧が5人のまま変わらないこと

## テスト

- `AppStateContext.jest.test.tsx`: 5人目登録・6人目拒否の境界条件テストを追加
- `ProfileManagerScreen.ui.jest.test.tsx`: グレーアウト・Alert 表示のUIテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)