### PR TITLE
feat: UIリデザイン — きろく一覧・記録詳細レイアウト刷新

### DIFF
--- a/__tests__/AchievementListScreen.ui.jest.test.tsx
+++ b/__tests__/AchievementListScreen.ui.jest.test.tsx
@@ -1,37 +1,38 @@
-import React from 'react';
-import { render } from '@testing-library/react-native';
+import React from "react";
+import { render } from "@testing-library/react-native";
 
 let mockActiveUser: any = null;
 let mockStore: any = {};
 let mockLoading = false;
 
-jest.mock('@react-navigation/native', () => ({
+jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
 }));
 
-jest.mock('@expo/vector-icons', () => ({
+jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
 }));
 
-jest.mock('@/components/AppText', () => {
-  const React = require('react');
-  const { Text } = require('react-native');
+jest.mock("@/components/AppText", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
   return {
     __esModule: true,
-    default: ({ children, style }: any) => React.createElement(Text, { style }, children),
+    default: ({ children, style }: any) =>
+      React.createElement(Text, { style }, children),
   };
 });
 
-jest.mock('@/components/DatePickerModal', () => ({
+jest.mock("@/components/DatePickerModal", () => ({
   __esModule: true,
   default: () => null,
 }));
 
-jest.mock('@/state/AppStateContext', () => ({
+jest.mock("@/state/AppStateContext", () => ({
   useActiveUser: () => mockActiveUser,
 }));
 
-jest.mock('@/state/AchievementsContext', () => ({
+jest.mock("@/state/AchievementsContext", () => ({
   useAchievements: () => ({ loading: mockLoading, store: mockStore }),
 }));
 
@@ -39,67 +40,71 @@ const mockNavigation = { navigate: jest.fn() };
 const mockRoute = { params: {} };
 
 const renderScreen = () => {
-  const AchievementListScreen = require('../src/screens/AchievementListScreen').default;
+  const AchievementListScreen =
+    require("../src/screens/AchievementListScreen").default;
   return render(
-    React.createElement(AchievementListScreen, { navigation: mockNavigation, route: mockRoute })
+    React.createElement(AchievementListScreen, {
+      navigation: mockNavigation,
+      route: mockRoute,
+    })
   );
 };
 
-describe('AchievementListScreen UI (TS-UI-007)', () => {
+describe("AchievementListScreen UI (TS-UI-007)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockStore = {};
     mockLoading = false;
     mockActiveUser = {
-      id: 'u1',
-      name: 'テストちゃん',
-      birthDate: '2024-01-01',
+      id: "u1",
+      name: "テストちゃん",
+      birthDate: "2024-01-01",
       dueDate: null,
       settings: {
         showCorrectedUntilMonths: 24,
-        ageFormat: 'ymd',
+        ageFormat: "ymd",
         showDaysSinceBirth: true,
         lastViewedMonth: null,
       },
     };
   });
 
-  test('記録なし: まだ記録がありませんを表示', () => {
+  test("記録なし: まだ記録がありませんを表示", () => {
     const { queryByText } = renderScreen();
-    expect(queryByText('まだ記録がありません')).not.toBeNull();
+    expect(queryByText("まだ記録がありません")).not.toBeNull();
   });
 
-  test('ローディング中: 読み込み中...を表示', () => {
+  test("ローディング中: 読み込み中...を表示", () => {
     mockLoading = true;
     const { queryByText } = renderScreen();
-    expect(queryByText('読み込み中...')).not.toBeNull();
+    expect(queryByText("読み込み中...")).not.toBeNull();
   });
 
-  test('記録あり: 記録タイトルを表示', () => {
+  test("記録あり: 記録タイトルを表示", () => {
     mockStore = {
-      '2024-06-01': [
+      "2024-06-01": [
         {
-          id: 'r1',
-          date: '2024-06-01',
-          title: '初めてのつかまり立ち',
-          memo: '',
-          createdAt: '2024-06-01T00:00:00.000Z',
-          updatedAt: '2024-06-01T00:00:00.000Z',
+          id: "r1",
+          date: "2024-06-01",
+          title: "初めてのつかまり立ち",
+          memo: "",
+          createdAt: "2024-06-01T00:00:00.000Z",
+          updatedAt: "2024-06-01T00:00:00.000Z",
         },
       ],
     };
     const { queryByText } = renderScreen();
-    expect(queryByText('初めてのつかまり立ち')).not.toBeNull();
+    expect(queryByText("初めてのつかまり立ち")).not.toBeNull();
   });
 
-  test('user=null: プロフィール未設定のヘッダーを表示', () => {
+  test("user=null: プロフィール未設定のヘッダーを表示", () => {
     mockActiveUser = null;
     const { queryByText } = renderScreen();
-    expect(queryByText('プロフィール未設定 記録一覧')).not.toBeNull();
+    expect(queryByText("プロフィール未設定")).not.toBeNull();
   });
 
-  test('FABボタン（＋記録）が描画される', () => {
+  test("FABボタン（＋記録）が描画される", () => {
     const { queryByText } = renderScreen();
-    expect(queryByText('＋記録')).not.toBeNull();
+    expect(queryByText("＋記録")).not.toBeNull();
   });
 });

--- a/__tests__/RecordDetailScreen.ui.jest.test.tsx
+++ b/__tests__/RecordDetailScreen.ui.jest.test.tsx
@@ -1,31 +1,32 @@
-import React from 'react';
-import renderer, { act } from 'react-test-renderer';
+import React from "react";
+import renderer, { act } from "react-test-renderer";
 
 let mockActiveUser: any = null;
 let mockStore: any = {};
 
-jest.mock('@expo/vector-icons', () => ({
+jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
 }));
 
-jest.mock('@/components/AppText', () => {
-  const React = require('react');
-  const { Text } = require('react-native');
+jest.mock("@/components/AppText", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
   return {
     __esModule: true,
-    default: ({ children, style }: any) => React.createElement(Text, { style }, children),
+    default: ({ children, style }: any) =>
+      React.createElement(Text, { style }, children),
   };
 });
 
-jest.mock('@/state/AppStateContext', () => ({
+jest.mock("@/state/AppStateContext", () => ({
   useActiveUser: () => mockActiveUser,
 }));
 
-jest.mock('@/state/AchievementsContext', () => ({
+jest.mock("@/state/AchievementsContext", () => ({
   useAchievements: () => ({ store: mockStore }),
 }));
 
-jest.mock('@/utils/photo', () => ({
+jest.mock("@/utils/photo", () => ({
   ensureFileExistsAsync: jest.fn().mockResolvedValue(null),
 }));
 
@@ -35,103 +36,127 @@ const mockNavigation = {
   replace: jest.fn(),
 };
 
-describe('RecordDetailScreen UI (TS-UI-006)', () => {
+describe("RecordDetailScreen UI (TS-UI-006)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockStore = {};
     mockActiveUser = {
-      id: 'u1',
-      name: 'テストちゃん',
-      birthDate: '2024-01-01',
+      id: "u1",
+      name: "テストちゃん",
+      birthDate: "2024-01-01",
       dueDate: null,
       settings: {
         showCorrectedUntilMonths: 24,
-        ageFormat: 'ymd',
+        ageFormat: "ymd",
         showDaysSinceBirth: true,
         lastViewedMonth: null,
       },
     };
   });
 
-  test('record=null: 記録が見つかりませんを表示', async () => {
+  test("record=null: 記録が見つかりませんを表示", async () => {
     mockStore = {};
-    const route = { params: { recordId: 'nonexistent', isoDate: '2024-06-01', from: 'today' } };
-    const RecordDetailScreen = require('../src/screens/RecordDetailScreen').default;
+    const route = {
+      params: { recordId: "nonexistent", isoDate: "2024-06-01", from: "today" },
+    };
+    const RecordDetailScreen =
+      require("../src/screens/RecordDetailScreen").default;
     let tree: any;
     await act(async () => {
       tree = renderer.create(
-        React.createElement(RecordDetailScreen, { navigation: mockNavigation, route })
+        React.createElement(RecordDetailScreen, {
+          navigation: mockNavigation,
+          route,
+        })
       );
     });
     const json = JSON.stringify(tree.toJSON());
-    expect(json).toContain('記録が見つかりません');
+    expect(json).toContain("記録が見つかりません");
   });
 
-  test('from=list のとき「戻る」ボタンを表示', async () => {
+  test("from=list のとき「戻る」ボタンを表示", async () => {
     mockStore = {};
-    const route = { params: { recordId: 'nonexistent', isoDate: '2024-06-01', from: 'list' } };
-    const RecordDetailScreen = require('../src/screens/RecordDetailScreen').default;
+    const route = {
+      params: { recordId: "nonexistent", isoDate: "2024-06-01", from: "list" },
+    };
+    const RecordDetailScreen =
+      require("../src/screens/RecordDetailScreen").default;
     let tree: any;
     await act(async () => {
       tree = renderer.create(
-        React.createElement(RecordDetailScreen, { navigation: mockNavigation, route })
+        React.createElement(RecordDetailScreen, {
+          navigation: mockNavigation,
+          route,
+        })
       );
     });
     const json = JSON.stringify(tree.toJSON());
-    expect(json).toContain('戻る');
+    expect(json).toContain("戻る");
   });
 
-  test('record あり: 記録詳細を表示', async () => {
+  test("record あり: 記録詳細を表示", async () => {
     mockStore = {
-      '2024-06-01': [
+      "2024-06-01": [
         {
-          id: 'r1',
-          date: '2024-06-01',
-          title: '初めての寝返り',
-          memo: 'とても嬉しかった',
-          createdAt: '2024-06-01T00:00:00.000Z',
-          updatedAt: '2024-06-01T00:00:00.000Z',
+          id: "r1",
+          date: "2024-06-01",
+          title: "初めての寝返り",
+          memo: "とても嬉しかった",
+          createdAt: "2024-06-01T00:00:00.000Z",
+          updatedAt: "2024-06-01T00:00:00.000Z",
         },
       ],
     };
-    const route = { params: { recordId: 'r1', isoDate: '2024-06-01', from: 'today' } };
-    const RecordDetailScreen = require('../src/screens/RecordDetailScreen').default;
+    const route = {
+      params: { recordId: "r1", isoDate: "2024-06-01", from: "today" },
+    };
+    const RecordDetailScreen =
+      require("../src/screens/RecordDetailScreen").default;
     let tree: any;
     await act(async () => {
       tree = renderer.create(
-        React.createElement(RecordDetailScreen, { navigation: mockNavigation, route })
+        React.createElement(RecordDetailScreen, {
+          navigation: mockNavigation,
+          route,
+        })
       );
     });
     const json = JSON.stringify(tree.toJSON());
-    expect(json).toContain('初めての寝返り');
-    expect(json).toContain('とても嬉しかった');
-    expect(json).toContain('編集する');
+    expect(json).toContain("初めての寝返り");
+    expect(json).toContain("とても嬉しかった");
+    expect(json).toContain("編集");
   });
 
-  test('user.name なし: ヘッダーが「記録」になる', async () => {
+  test("user.name なし: ヘッダーが「記録」になる", async () => {
     mockActiveUser = null;
     mockStore = {
-      '2024-06-01': [
+      "2024-06-01": [
         {
-          id: 'r1',
-          date: '2024-06-01',
-          title: 'テスト',
-          memo: '',
-          createdAt: '2024-06-01T00:00:00.000Z',
-          updatedAt: '2024-06-01T00:00:00.000Z',
+          id: "r1",
+          date: "2024-06-01",
+          title: "テスト",
+          memo: "",
+          createdAt: "2024-06-01T00:00:00.000Z",
+          updatedAt: "2024-06-01T00:00:00.000Z",
         },
       ],
     };
-    const route = { params: { recordId: 'r1', isoDate: '2024-06-01', from: 'today' } };
-    const RecordDetailScreen = require('../src/screens/RecordDetailScreen').default;
+    const route = {
+      params: { recordId: "r1", isoDate: "2024-06-01", from: "today" },
+    };
+    const RecordDetailScreen =
+      require("../src/screens/RecordDetailScreen").default;
     let tree: any;
     await act(async () => {
       tree = renderer.create(
-        React.createElement(RecordDetailScreen, { navigation: mockNavigation, route })
+        React.createElement(RecordDetailScreen, {
+          navigation: mockNavigation,
+          route,
+        })
       );
     });
     const json = JSON.stringify(tree.toJSON());
     // user?.name が null なのでヘッダーは "記録" になる
-    expect(json).toContain('記録');
+    expect(json).toContain("記録");
   });
 });

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "リトルベビーログ",
     "slug": "little-baby-log",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "homepage": "https://tsuku723.github.io/little-baby-log/",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -15,7 +15,7 @@
     },
     "ios": {
       "bundleIdentifier": "studio.teeda.littlebabylog",
-      "buildNumber": "2",
+      "buildNumber": "3",
       "supportsTablet": false,
       "infoPlist": {
         "CFBundleDevelopmentRegion": "ja_JP",

--- a/src/components/AgeBadge.tsx
+++ b/src/components/AgeBadge.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { COLORS } from "@/constants/colors";
+
+type Variant = "chronological" | "corrected" | "gestational";
+
+const BG: Record<Variant, string> = {
+  chronological: COLORS.ageBadgeChronologicalBg,
+  corrected: COLORS.ageBadgeCorrectedBg,
+  gestational: COLORS.ageBadgeGestationalBg,
+};
+
+type Props = {
+  label: string;
+  variant: Variant;
+};
+
+const AgeBadge: React.FC<Props> = ({ label, variant }) => (
+  <View style={[styles.badge, { backgroundColor: BG[variant] }]}>
+    <Text style={styles.text}>{label}</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  badge: {
+    borderRadius: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  text: {
+    fontSize: 12,
+    color: COLORS.ageBadgeText,
+    fontWeight: "600",
+  },
+});
+
+export default AgeBadge;

--- a/src/screens/AchievementListScreen.tsx
+++ b/src/screens/AchievementListScreen.tsx
@@ -1,36 +1,292 @@
-﻿import React, { useMemo, useState } from "react";
-import { FlatList, SafeAreaView, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
+import React, { useMemo, useState } from "react";
+import {
+  Image,
+  SafeAreaView,
+  SectionList,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
 
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Ionicons } from "@expo/vector-icons";
 
 import { Achievement } from "@/models/dataModels";
-import { RecordListStackParamList, RootStackParamList, TabParamList } from "@/navigation";
+import {
+  RecordListStackParamList,
+  RootStackParamList,
+  TabParamList,
+} from "@/navigation";
+import AgeBadge from "@/components/AgeBadge";
 import AppText from "@/components/AppText";
 import DatePickerModal from "@/components/DatePickerModal";
 import { useAchievements } from "@/state/AchievementsContext";
 import { useActiveUser } from "@/state/AppStateContext";
-import { isIsoDateString, safeParseIsoLocal, toIsoDateString } from "@/utils/dateUtils";
+import { UserProfile } from "@/state/AppStateContext";
+import {
+  calculateAgeInfo,
+  isIsoDateString,
+  safeParseIsoLocal,
+  toIsoDateString,
+} from "@/utils/dateUtils";
+import { ensureFileExistsAsync } from "@/utils/photo";
 import { normalizeSearchText } from "@/utils/text";
 import { COLORS } from "@/constants/colors";
 
-type Props = NativeStackScreenProps<RecordListStackParamList, "AchievementList">;
+type Props = NativeStackScreenProps<
+  RecordListStackParamList,
+  "AchievementList"
+>;
 type RootNavigation = NavigationProp<RootStackParamList & TabParamList>;
 
-const dateLabel = (iso: string): string => iso.replace(/-/g, "/");
-const startOfLocalDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+const startOfLocalDay = (d: Date) =>
+  new Date(d.getFullYear(), d.getMonth(), d.getDate());
 const cloneDate = (d: Date) => new Date(d.getTime());
 
-const toIsoDateFromPicker = (picked: Date): string => {
-  return toIsoDateString(picked);
-};
+const toIsoDateFromPicker = (picked: Date): string => toIsoDateString(picked);
 
 const getPickerDate = (value: string | null, fallback: Date): Date => {
-  const parsed = safeParseIsoLocal(value && isIsoDateString(value) ? value : null, fallback);
+  const parsed = safeParseIsoLocal(
+    value && isIsoDateString(value) ? value : null,
+    fallback
+  );
   if (Number.isNaN(parsed.getTime())) return cloneDate(fallback);
   return cloneDate(parsed);
 };
+
+// ---- カード共通: 月齢バッジ行 ----
+
+type AgeBadgeRowProps = { record: Achievement; user: UserProfile };
+
+const AgeBadgeRow: React.FC<AgeBadgeRowProps> = ({ record, user }) => {
+  const ageInfo = useMemo(() => {
+    if (!user.birthDate) return null;
+    try {
+      return calculateAgeInfo({
+        targetDate: record.date,
+        birthDate: user.birthDate,
+        dueDate: user.dueDate,
+        showCorrectedUntilMonths: user.settings.showCorrectedUntilMonths,
+        ageFormat: user.settings.ageFormat,
+      });
+    } catch {
+      return null;
+    }
+  }, [record.date, user]);
+
+  if (!ageInfo) return null;
+
+  const showGestational =
+    ageInfo.flags.showMode === "gestational" &&
+    ageInfo.gestational.visible &&
+    ageInfo.gestational.formatted;
+  const showCorrected =
+    ageInfo.flags.showMode === "corrected" &&
+    ageInfo.corrected.visible &&
+    ageInfo.corrected.formatted;
+
+  return (
+    <View style={badgeRowStyles.row}>
+      <AgeBadge
+        label={ageInfo.chronological.formatted}
+        variant="chronological"
+      />
+      {showGestational ? (
+        <AgeBadge
+          label={`在胎 ${ageInfo.gestational.formatted}`}
+          variant="gestational"
+        />
+      ) : showCorrected ? (
+        <AgeBadge
+          label={`修正 ${ageInfo.corrected.formatted}`}
+          variant="corrected"
+        />
+      ) : null}
+    </View>
+  );
+};
+
+const badgeRowStyles = StyleSheet.create({
+  row: { flexDirection: "row", flexWrap: "wrap", gap: 6, marginTop: 6 },
+});
+
+// ---- 標準カード（右サムネイル）----
+
+type RecordCardProps = {
+  item: Achievement;
+  user: UserProfile;
+  onPress: () => void;
+};
+
+const RecordCard: React.FC<RecordCardProps> = ({ item, user, onPress }) => {
+  const [resolvedPhoto, setResolvedPhoto] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    void ensureFileExistsAsync(item.photoPath ?? null).then((path) => {
+      if (mounted) setResolvedPhoto(path);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [item.photoPath]);
+
+  return (
+    <TouchableOpacity
+      style={cardStyles.card}
+      onPress={onPress}
+      accessibilityRole="button"
+    >
+      <View style={cardStyles.left}>
+        <Text style={cardStyles.date}>{item.date.replace(/-/g, "/")}</Text>
+        <Text style={cardStyles.title} numberOfLines={2}>
+          {item.title || "(タイトルなし)"}
+        </Text>
+        {item.memo ? (
+          <Text style={cardStyles.memo} numberOfLines={2}>
+            {item.memo}
+          </Text>
+        ) : null}
+        <AgeBadgeRow record={item} user={user} />
+      </View>
+      <View style={cardStyles.thumb}>
+        {resolvedPhoto ? (
+          <Image
+            source={{ uri: resolvedPhoto }}
+            style={cardStyles.thumbImage}
+            resizeMode="cover"
+          />
+        ) : (
+          <View style={cardStyles.thumbPlaceholder}>
+            <Ionicons
+              name="camera-outline"
+              size={22}
+              color={COLORS.textSecondary}
+            />
+          </View>
+        )}
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+const cardStyles = StyleSheet.create({
+  card: {
+    backgroundColor: COLORS.surface,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    padding: 12,
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+  },
+  left: { flex: 1, gap: 2 },
+  date: { fontSize: 12, color: COLORS.textSecondary },
+  title: { fontSize: 16, fontWeight: "700", color: COLORS.textPrimary },
+  memo: { fontSize: 14, color: COLORS.textSecondary, lineHeight: 20 },
+  thumb: {
+    width: 72,
+    height: 72,
+    borderRadius: 8,
+    overflow: "hidden",
+    flexShrink: 0,
+  },
+  thumbImage: { width: "100%", height: "100%" },
+  thumbPlaceholder: {
+    width: "100%",
+    height: "100%",
+    backgroundColor: COLORS.cellDimmed,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});
+
+// ---- フィーチャーカード（写真大）----
+
+const FeaturedCard: React.FC<RecordCardProps> = ({ item, user, onPress }) => {
+  const [resolvedPhoto, setResolvedPhoto] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    void ensureFileExistsAsync(item.photoPath ?? null).then((path) => {
+      if (mounted) setResolvedPhoto(path);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [item.photoPath]);
+
+  return (
+    <TouchableOpacity
+      style={featuredStyles.card}
+      onPress={onPress}
+      accessibilityRole="button"
+    >
+      <View style={featuredStyles.photoArea}>
+        {resolvedPhoto ? (
+          <Image
+            source={{ uri: resolvedPhoto }}
+            style={featuredStyles.photo}
+            resizeMode="cover"
+          />
+        ) : (
+          <View style={featuredStyles.photoPlaceholder}>
+            <Ionicons
+              name="camera-outline"
+              size={32}
+              color={COLORS.textSecondary}
+            />
+          </View>
+        )}
+      </View>
+      <View style={featuredStyles.body}>
+        <Text style={featuredStyles.date}>{item.date.replace(/-/g, "/")}</Text>
+        <Text style={featuredStyles.title} numberOfLines={2}>
+          {item.title || "(タイトルなし)"}
+        </Text>
+        {item.memo ? (
+          <Text style={featuredStyles.memo} numberOfLines={2}>
+            {item.memo}
+          </Text>
+        ) : null}
+        <AgeBadgeRow record={item} user={user} />
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+const featuredStyles = StyleSheet.create({
+  card: {
+    backgroundColor: COLORS.surface,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    overflow: "hidden",
+  },
+  photoArea: { width: "100%", height: 200 },
+  photo: { width: "100%", height: "100%" },
+  photoPlaceholder: {
+    width: "100%",
+    height: "100%",
+    backgroundColor: COLORS.cellDimmed,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  body: { padding: 12, gap: 4 },
+  date: { fontSize: 12, color: COLORS.textSecondary },
+  title: { fontSize: 16, fontWeight: "700", color: COLORS.textPrimary },
+  memo: { fontSize: 14, color: COLORS.textSecondary, lineHeight: 20 },
+});
+
+// ---- セクションデータ型 ----
+
+type CardItem = { record: Achievement; isFeatured: boolean };
+
+// ---- メイン画面 ----
 
 const AchievementListScreen: React.FC<Props> = () => {
   const rootNavigation = useNavigation<RootNavigation>();
@@ -65,20 +321,34 @@ const AchievementListScreen: React.FC<Props> = () => {
     setPickerValue(getPickerDate(target === "from" ? fromDate : toDate, today));
   };
 
-  const items = useMemo(() => {
-    // AchievementStore = { "2025-02-05": [A], "2025-02-06": [B, C], ... }
-    const allList: Achievement[] = Object.values(store).flat();
+  // 今日の月齢（ヘッダー表示用）
+  const todayAgeInfo = useMemo(() => {
+    if (!user?.birthDate) return null;
+    try {
+      return calculateAgeInfo({
+        targetDate: toIsoDateString(today),
+        birthDate: user.birthDate,
+        dueDate: user.dueDate,
+        showCorrectedUntilMonths: user.settings.showCorrectedUntilMonths,
+        ageFormat: user.settings.ageFormat,
+      });
+    } catch {
+      return null;
+    }
+  }, [today, user]);
 
-    // 1) フリーワード検索（title / memo 部分一致）
+  // フィルタ後のフラットリスト
+  const items = useMemo(() => {
+    const allList: Achievement[] = Object.values(store).flat();
     const normalizedQuery = normalizeSearchText(searchText);
     const filteredBySearch = normalizedQuery
       ? allList.filter((item) => {
-          const normalizedTarget = normalizeSearchText(`${item.title} ${item.memo ?? ""}`);
+          const normalizedTarget = normalizeSearchText(
+            `${item.title} ${item.memo ?? ""}`
+          );
           return normalizedTarget.includes(normalizedQuery);
         })
       : allList;
-
-    // 2) 期間フィルタ（日付は ISO 形式で比較 OK）
     const validFrom = fromDate && isIsoDateString(fromDate) ? fromDate : null;
     const validTo = toDate && isIsoDateString(toDate) ? toDate : null;
     const filteredByRange = filteredBySearch.filter((item) => {
@@ -86,45 +356,106 @@ const AchievementListScreen: React.FC<Props> = () => {
       if (validTo && item.date > validTo) return false;
       return true;
     });
-
-    // 3) ソート: date desc, createdAt desc
-    return filteredByRange
-      .slice()
-      .sort((a, b) => {
-        if (a.date === b.date) return (b.createdAt ?? "").localeCompare(a.createdAt ?? "");
-        return b.date.localeCompare(a.date);
-      });
+    return filteredByRange.slice().sort((a, b) => {
+      if (a.date === b.date)
+        return (b.createdAt ?? "").localeCompare(a.createdAt ?? "");
+      return b.date.localeCompare(a.date);
+    });
   }, [fromDate, searchText, store, toDate]);
 
-  const renderItem = ({ item }: { item: Achievement }) => (
-    <TouchableOpacity
-      style={styles.row}
-      onPress={() => {
-        rootNavigation.navigate("RecordDetail", { recordId: item.id, from: "list" });
-      }}
-      accessibilityRole="button"
-    >
-      {/* 行タップでカレンダー画面の該当日を開く */}
-      <View style={styles.rowHeader}>
-        <Text style={styles.date}>{dateLabel(item.date)}</Text>
-      </View>
-      <Text style={styles.rowTitle} numberOfLines={2}>
-        {item.title}
-      </Text>
-      {item.memo ? (
-        <Text style={styles.memo} numberOfLines={2}>
-          {item.memo}
-        </Text>
-      ) : null}
-    </TouchableOpacity>
+  // 月ごとにグループ化してセクション配列を生成
+  const sections = useMemo(() => {
+    const groups: Record<string, Achievement[]> = {};
+    items.forEach((item) => {
+      const key = item.date.slice(0, 7); // YYYY-MM
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(item);
+    });
+
+    return Object.entries(groups)
+      .sort(([a], [b]) => b.localeCompare(a))
+      .map(([key, records]) => {
+        // 各月で最も新しい（先頭の）写真付き記録をフィーチャー
+        const featuredId = records.find((r) => r.photoPath)?.id ?? null;
+        const year = parseInt(key.slice(0, 4), 10);
+        const month = parseInt(key.slice(5, 7), 10);
+        return {
+          title: `${year}年${month}月`,
+          data: records.map((r) => ({
+            record: r,
+            isFeatured: r.id === featuredId,
+          })) as CardItem[],
+        };
+      });
+  }, [items]);
+
+  const navigateToRecord = (recordId: string) => {
+    rootNavigation.navigate("RecordDetail", { recordId, from: "list" });
+  };
+
+  const renderItem = ({ item }: { item: CardItem }) => {
+    if (!user) return null;
+    if (item.isFeatured) {
+      return (
+        <FeaturedCard
+          item={item.record}
+          user={user}
+          onPress={() => navigateToRecord(item.record.id)}
+        />
+      );
+    }
+    return (
+      <RecordCard
+        item={item.record}
+        user={user}
+        onPress={() => navigateToRecord(item.record.id)}
+      />
+    );
+  };
+
+  const renderSectionHeader = ({ section }: { section: { title: string } }) => (
+    <View style={styles.sectionHeader}>
+      <Text style={styles.sectionHeaderText}>{section.title}</Text>
+    </View>
   );
 
   return (
     <SafeAreaView style={styles.safeArea}>
+      {/* ヘッダー：名前 ＋ 今日の月齢 */}
       <View style={styles.header}>
-        <AppText style={styles.headerTitle} weight="medium">
-          {(user?.name ?? "プロフィール未設定") + " 記録一覧"}
+        <AppText style={styles.headerName} weight="medium">
+          {user?.name ?? "プロフィール未設定"}
         </AppText>
+        {todayAgeInfo ? (
+          <View style={styles.headerAgeBlock}>
+            {todayAgeInfo.flags.showMode === "gestational" &&
+            todayAgeInfo.gestational.formatted ? (
+              <Text style={styles.headerChronological}>
+                {todayAgeInfo.chronological.formatted}
+                <Text style={styles.headerCorrected}>
+                  （在胎 {todayAgeInfo.gestational.formatted}）
+                </Text>
+              </Text>
+            ) : todayAgeInfo.corrected.visible &&
+              todayAgeInfo.corrected.formatted ? (
+              <Text style={styles.headerChronological}>
+                {todayAgeInfo.chronological.formatted}
+                <Text style={styles.headerCorrected}>
+                  （修正 {todayAgeInfo.corrected.formatted}）
+                </Text>
+              </Text>
+            ) : (
+              <Text style={styles.headerChronological}>
+                {todayAgeInfo.chronological.formatted}
+              </Text>
+            )}
+            {user?.settings.showDaysSinceBirth ? (
+              <Text style={styles.headerDays}>
+                生まれてから{todayAgeInfo.daysSinceBirth}日目
+              </Text>
+            ) : null}
+          </View>
+        ) : null}
       </View>
       <View style={styles.content}>
         <View style={styles.filterBar}>
@@ -141,7 +472,11 @@ const AchievementListScreen: React.FC<Props> = () => {
             accessibilityRole="button"
             accessibilityLabel="絞り込みを切り替える"
           >
-            <Ionicons name="options-outline" size={20} color={COLORS.textSecondary} />
+            <Ionicons
+              name="options-outline"
+              size={20}
+              color={COLORS.textSecondary}
+            />
           </TouchableOpacity>
         </View>
         {isFilterExpanded ? (
@@ -154,7 +489,11 @@ const AchievementListScreen: React.FC<Props> = () => {
             >
               <Text style={styles.filterLabel}>From</Text>
               <Text style={styles.filterValue}>{fromDate ?? "未設定"}</Text>
-              <Ionicons name="calendar-outline" size={18} color={COLORS.textSecondary} />
+              <Ionicons
+                name="calendar-outline"
+                size={18}
+                color={COLORS.textSecondary}
+              />
             </TouchableOpacity>
             <TouchableOpacity
               style={styles.filterRow}
@@ -164,7 +503,11 @@ const AchievementListScreen: React.FC<Props> = () => {
             >
               <Text style={styles.filterLabel}>To</Text>
               <Text style={styles.filterValue}>{toDate ?? "未設定"}</Text>
-              <Ionicons name="calendar-outline" size={18} color={COLORS.textSecondary} />
+              <Ionicons
+                name="calendar-outline"
+                size={18}
+                color={COLORS.textSecondary}
+              />
             </TouchableOpacity>
             <TouchableOpacity
               style={styles.clearButton}
@@ -178,18 +521,24 @@ const AchievementListScreen: React.FC<Props> = () => {
             </TouchableOpacity>
           </View>
         ) : null}
-        <FlatList
-          data={items}
-          keyExtractor={(item) => item.id}
+        <SectionList
+          sections={sections}
+          keyExtractor={(item) => item.record.id}
           renderItem={renderItem}
+          renderSectionHeader={renderSectionHeader}
           contentContainerStyle={styles.list}
-          ListEmptyComponent={<Text style={styles.empty}>{loading ? "読み込み中..." : "まだ記録がありません"}</Text>}
+          stickySectionHeadersEnabled={false}
+          ListEmptyComponent={
+            <Text style={styles.empty}>
+              {loading ? "読み込み中..." : "まだ記録がありません"}
+            </Text>
+          }
+          ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
         />
       </View>
       <TouchableOpacity
         style={styles.fab}
         accessibilityRole="button"
-        // Phase 1: FAB は記録入力画面への入口だけを保持
         onPress={() => rootNavigation.navigate("RecordInput")}
       >
         <Text style={styles.fabText}>＋記録</Text>
@@ -231,14 +580,34 @@ const styles = StyleSheet.create({
   },
   header: {
     alignItems: "center",
-    justifyContent: "center",
-    paddingVertical: 12,
     paddingHorizontal: 16,
+    paddingVertical: 6,
     backgroundColor: COLORS.headerBackground,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.border,
+    gap: 6,
   },
-  headerTitle: {
-    fontSize: 18,
+  headerName: {
+    fontSize: 20,
     color: COLORS.textPrimary,
+    textAlign: "center",
+  },
+  headerAgeBlock: {
+    alignItems: "center",
+    gap: 4,
+  },
+  headerChronological: {
+    fontSize: 14,
+    color: COLORS.textPrimary,
+    textAlign: "center",
+  },
+  headerCorrected: {
+    fontSize: 14,
+    color: COLORS.accentMain,
+  },
+  headerDays: {
+    fontSize: 12,
+    color: COLORS.textSecondary,
     textAlign: "center",
   },
   filterBar: {
@@ -297,35 +666,17 @@ const styles = StyleSheet.create({
     color: COLORS.textSecondary,
   },
   list: {
-    gap: 12,
+    gap: 0,
     paddingBottom: 120,
   },
-  row: {
-    backgroundColor: COLORS.surface,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: COLORS.border,
-    padding: 12,
-    gap: 6,
+  sectionHeader: {
+    paddingVertical: 8,
+    paddingHorizontal: 4,
   },
-  rowHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-  date: {
-    fontSize: 14,
-    color: COLORS.textSecondary,
-  },
-  rowTitle: {
-    fontSize: 16,
+  sectionHeaderText: {
+    fontSize: 15,
     fontWeight: "700",
-    color: COLORS.textPrimary,
-  },
-  memo: {
-    fontSize: 14,
     color: COLORS.textSecondary,
-    lineHeight: 20,
   },
   empty: {
     fontSize: 16,

--- a/src/screens/RecordDetailScreen.tsx
+++ b/src/screens/RecordDetailScreen.tsx
@@ -1,10 +1,20 @@
-﻿import React, { useEffect, useMemo, useState } from "react";
-import { Button, Image, SafeAreaView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  Image,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Ionicons } from "@expo/vector-icons";
 
 import { RootStackParamList } from "@/navigation";
+import AgeBadge from "@/components/AgeBadge";
 import AppText from "@/components/AppText";
 import { useActiveUser } from "@/state/AppStateContext";
 import { useAchievements } from "@/state/AchievementsContext";
@@ -15,14 +25,13 @@ import { COLORS } from "@/constants/colors";
 type Props = NativeStackScreenProps<RootStackParamList, "RecordDetail">;
 
 const RecordDetailScreen: React.FC<Props> = ({ navigation, route }) => {
-  // 選択中ベビー名取得（ベビー名のない場合は "記録" のまま）
   const user = useActiveUser();
   const { recordId, isoDate, from } = route.params ?? {};
   const { store, loading } = useAchievements();
   const [photoPath, setPhotoPath] = useState<string | null>(null);
 
   const record = useMemo(() => {
-    const scoped = isoDate ? store[isoDate] ?? [] : [];
+    const scoped = isoDate ? (store[isoDate] ?? []) : [];
     if (scoped.length > 0) {
       const hit = scoped.find((item) => item.id === recordId);
       if (hit) return hit;
@@ -64,19 +73,25 @@ const RecordDetailScreen: React.FC<Props> = ({ navigation, route }) => {
     return (
       <SafeAreaView style={styles.safeArea}>
         <View style={styles.centered}>
-          <Text style={styles.title}>記録が見つかりません</Text>
-          <Button
-            title="戻る"
-            onPress={() => navigation.goBack()}
-          />
+          <Text style={styles.notFoundText}>記録が見つかりません</Text>
+          <Button title="戻る" onPress={() => navigation.goBack()} />
         </View>
       </SafeAreaView>
     );
   }
 
+  const showGestational =
+    ageInfo?.flags.showMode === "gestational" &&
+    ageInfo.gestational.visible &&
+    ageInfo.gestational.formatted;
+  const showCorrected =
+    ageInfo?.flags.showMode === "corrected" &&
+    ageInfo.corrected.visible &&
+    ageInfo.corrected.formatted;
+
   return (
     <SafeAreaView style={styles.safeArea}>
-      {/* ヘッダー：左に戻るボタン、中央に「ベビー名の記録」 */}
+      {/* ヘッダー：戻る | タイトル | 編集テキストリンク */}
       <View style={styles.header}>
         <TouchableOpacity
           style={styles.headerLeft}
@@ -89,68 +104,74 @@ const RecordDetailScreen: React.FC<Props> = ({ navigation, route }) => {
         <AppText weight="medium" style={styles.headerTitle}>
           {user?.name ? `${user.name}の記録` : "記録"}
         </AppText>
-        {/* プレースホルダ（中央揃え用） */}
-        <View style={styles.headerRight} />
+        <TouchableOpacity
+          style={styles.headerRight}
+          onPress={() =>
+            navigation.navigate("RecordInput", {
+              recordId: record.id,
+              isoDate: record.date,
+              from,
+            })
+          }
+          accessibilityRole="button"
+          accessibilityLabel="編集"
+        >
+          <Text style={styles.editLink}>編集</Text>
+        </TouchableOpacity>
       </View>
-      <View style={styles.container}>
-        <Text style={styles.title}>{record.title || "(タイトル未入力)"}</Text>
-        <View style={styles.field}>
-          <Text style={styles.label}>日付</Text>
-          <Text style={styles.value}>{record.date.replace(/-/g, "/")}</Text>
-        </View>
 
-        {ageInfo ? (
-          <View style={styles.field}>
-            <Text style={styles.label}>月齢</Text>
-            <View style={styles.ageBlock}>
-              {ageInfo.flags.showMode === "gestational" && ageInfo.gestational.visible && ageInfo.gestational.formatted ? (
-                <View style={styles.ageRow}>
-                  <Text style={styles.ageValue}>{ageInfo.chronological.formatted}</Text>
-                  <Text style={styles.ageNote}>（在胎 {ageInfo.gestational.formatted}）</Text>
-                </View>
-              ) : ageInfo.corrected.visible && ageInfo.corrected.formatted ? (
-                <View style={styles.ageRow}>
-                  <Text style={styles.ageValue}>{ageInfo.chronological.formatted}</Text>
-                  <Text style={styles.ageNote}>（修正 {ageInfo.corrected.formatted}）</Text>
-                </View>
-              ) : (
-                <View style={styles.ageRow}>
-                  <Text style={styles.ageValue}>{ageInfo.chronological.formatted}</Text>
-                </View>
-              )}
-              {user?.settings.showDaysSinceBirth ? (
-                <Text style={styles.ageNote}>生まれてから{ageInfo.daysSinceBirth}日目</Text>
-              ) : null}
-            </View>
-          </View>
-        ) : null}
+      <ScrollView contentContainerStyle={styles.container}>
+        {/* 日付（写真の上に小さく） */}
+        <Text style={styles.date}>{record.date.replace(/-/g, "/")}</Text>
 
-        {record.memo ? (
-          <View style={styles.field}>
-            <Text style={styles.label}>メモ</Text>
-            <Text style={styles.value}>{record.memo}</Text>
-          </View>
-        ) : null}
-
+        {/* 写真 */}
         {photoPath ? (
-          <View style={styles.field}>
-            <Text style={styles.label}>写真</Text>
-            <Image source={{ uri: photoPath }} style={styles.photo} resizeMode="cover" />
+          <Image
+            source={{ uri: photoPath }}
+            style={styles.photo}
+            resizeMode="cover"
+          />
+        ) : null}
+
+        {/* タイトル */}
+        <Text style={styles.title}>{record.title || "(タイトル未入力)"}</Text>
+
+        {/* 月齢バッジ行 */}
+        {ageInfo ? (
+          <View style={styles.badgeRow}>
+            <AgeBadge
+              label={ageInfo.chronological.formatted}
+              variant="chronological"
+            />
+            {showGestational ? (
+              <AgeBadge
+                label={`在胎 ${ageInfo.gestational.formatted}`}
+                variant="gestational"
+              />
+            ) : showCorrected ? (
+              <AgeBadge
+                label={`修正 ${ageInfo.corrected.formatted}`}
+                variant="corrected"
+              />
+            ) : null}
+            {user?.settings.showDaysSinceBirth ? (
+              <View style={styles.daysBadge}>
+                <Text style={styles.daysBadgeText}>
+                  {ageInfo.daysSinceBirth}日目
+                </Text>
+              </View>
+            ) : null}
           </View>
         ) : null}
 
-        <View style={styles.actions}>
-          <TouchableOpacity
-            style={[styles.actionButton, styles.editButton]}
-            onPress={() =>
-              navigation.navigate("RecordInput", { recordId: record.id, isoDate: record.date, from })
-            }
-            accessibilityRole="button"
-          >
-            <Text style={styles.actionButtonText}>編集する</Text>
-          </TouchableOpacity>
-        </View>
-      </View>
+        {/* メモ */}
+        {record.memo ? (
+          <View style={styles.memoSection}>
+            <Text style={styles.memoLabel}>メモ</Text>
+            <Text style={styles.memoBody}>{record.memo}</Text>
+          </View>
+        ) : null}
+      </ScrollView>
     </SafeAreaView>
   );
 };
@@ -160,67 +181,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: COLORS.background,
   },
-  container: {
-    flex: 1,
-    gap: 16,
-    padding: 24,
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: "700",
-    color: COLORS.textPrimary,
-  },
-  field: {
-    gap: 6,
-  },
-  label: {
-    fontSize: 14,
-    color: COLORS.textSecondary,
-  },
-  value: {
-    fontSize: 17,
-    color: COLORS.textPrimary,
-  },
-  ageBlock: {
-    gap: 4,
-  },
-  ageRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    flexWrap: "wrap",
-  },
-  ageValue: {
-    fontSize: 17,
-    color: COLORS.textPrimary,
-  },
-  ageNote: {
-    fontSize: 14,
-    color: COLORS.textSecondary,
-  },
-  actions: {
-    marginTop: 12,
-    alignItems: "center",
-  },
-  actionButton: {
-    backgroundColor: COLORS.filterBackground,
-    borderRadius: 12,
-    paddingVertical: 10,
-    paddingHorizontal: 14,
-    borderWidth: 1,
-    borderColor: COLORS.border,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  actionButtonText: {
-    fontSize: 14,
-    color: COLORS.textPrimary,
-    fontWeight: "600",
-  },
-  editButton: {
-    alignSelf: "center",
-  },
-  /* 記録詳細ヘッダー */
   header: {
     flexDirection: "row",
     alignItems: "center",
@@ -234,16 +194,73 @@ const styles = StyleSheet.create({
     left: 16,
     alignItems: "center",
     justifyContent: "center",
-  },
-  headerRight: {
-    position: "absolute",
-    right: 16,
-    width: 24,
-    height: 24,
+    padding: 4,
   },
   headerTitle: {
     fontSize: 18,
     color: COLORS.textPrimary,
+  },
+  headerRight: {
+    position: "absolute",
+    right: 16,
+    padding: 4,
+  },
+  editLink: {
+    fontSize: 15,
+    color: COLORS.accentMain,
+    fontWeight: "600",
+  },
+  container: {
+    padding: 20,
+    gap: 14,
+    paddingBottom: 48,
+  },
+  date: {
+    fontSize: 13,
+    color: COLORS.textSecondary,
+  },
+  photo: {
+    width: "100%",
+    height: 260,
+    borderRadius: 12,
+    backgroundColor: COLORS.cellDimmed,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: COLORS.textPrimary,
+    lineHeight: 32,
+  },
+  badgeRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  daysBadge: {
+    borderRadius: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    backgroundColor: COLORS.cellDimmed,
+  },
+  daysBadgeText: {
+    fontSize: 12,
+    color: COLORS.textSecondary,
+    fontWeight: "600",
+  },
+  memoSection: {
+    gap: 6,
+  },
+  memoLabel: {
+    fontSize: 12,
+    color: COLORS.textSecondary,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  memoBody: {
+    fontSize: 16,
+    color: COLORS.textPrimary,
+    lineHeight: 24,
   },
   centered: {
     flex: 1,
@@ -252,11 +269,9 @@ const styles = StyleSheet.create({
     gap: 12,
     padding: 24,
   },
-  photo: {
-    width: "100%",
-    height: 240,
-    borderRadius: 12,
-    backgroundColor: COLORS.cellDimmed,
+  notFoundText: {
+    fontSize: 18,
+    color: COLORS.textPrimary,
   },
 });
 


### PR DESCRIPTION
## 変更内容

Closes #174

### AchievementListScreen（きろく一覧）
- ヘッダーを CalendarScreen と同様の「名前 + 今日の月齢情報」スタイルに変更
- `FlatList` → `SectionList` に変更し、月ごとのセクションヘッダーを追加
- 各カードに右サムネイル（写真 or カメラプレースホルダー）を追加
- 各月の最新写真付き記録をフィーチャーカード（大カード）として表示
- 各カードに記録日時点の月齢バッジ（暦月齢・修正/在胎月齢）を追加

### RecordDetailScreen（記録詳細）
- 写真を画面上部に大きく表示
- 日付を写真の上に小さく表示
- タイトルを写真の下に大きく表示
- 月齢バッジ行（暦月齢・修正月齢・日数）を追加
- メモセクションを「メモ」ラベル + 本文の構成に変更
- 「編集する」ボタン → ヘッダー右上の「編集」テキストリンクに変更

### 共通
- `AgeBadge` コンポーネントを新規作成（`src/components/AgeBadge.tsx`）

## 確認手順

1. `npm start` で Expo 開発サーバーを起動
2. きろく一覧を開き、月ごとのセクションヘッダーが表示されることを確認
3. 写真付き記録が各月の先頭でフィーチャーカードになることを確認
4. 記録詳細を開き、写真上部 → タイトル → バッジ → メモの順に表示されることを確認
5. ヘッダー右上に「編集」リンクが表示され、タップで編集画面に遷移することを確認
6. 修正月齢設定ありのプロフィールで月齢バッジが正しく表示されることを確認

## テスト

- TypeScript 型チェック：通過
- Jest ユニットテスト：148件すべて通過（既存テストを新しい動作に合わせて更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)