### PR TITLE
chore: EAS Build ワークフロー追加・preview プロファイルを TestFlight 向けに変更

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,26 @@
+name: EAS Build (iOS)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: EAS Build iOS Preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli
+
+      - name: Build iOS (preview)
+        run: eas build --platform ios --profile preview --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/eas.json
+++ b/eas.json
@@ -9,7 +9,7 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "store"
     },
     "production": {
       "autoIncrement": true

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,14 @@
 module.exports = {
-  preset: 'jest-expo',
-  testMatch: ['**/__tests__/**/*.jest.test.{ts,tsx,js,jsx}'],
-  testPathIgnorePatterns: ['/node_modules/', '/__tests__/legacy/'],
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  preset: "jest-expo",
+  testMatch: ["**/__tests__/**/*.jest.test.{ts,tsx,js,jsx}"],
+  testPathIgnorePatterns: ["/node_modules/", "/__tests__/legacy/", "/.claude/"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   coveragePathIgnorePatterns: [
-    '<rootDir>/App.js',
-    '<rootDir>/src/models/dataModels.ts',
-    '<rootDir>/src/navigation/types.ts',
+    "<rootDir>/App.js",
+    "<rootDir>/src/models/dataModels.ts",
+    "<rootDir>/src/navigation/types.ts",
   ],
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1',
+    "^@/(.*)$": "<rootDir>/src/$1",
   },
 };


### PR DESCRIPTION
## 変更内容

- `.github/workflows/eas-build.yml` を新規作成
  - 手動トリガー（workflow_dispatch）で iOS 向け EAS Build を実行
  - `eas build --platform ios --profile preview --non-interactive`
  - `EXPO_TOKEN` は GitHub Secrets から参照
- `eas.json` の `preview` プロファイルを `distribution: internal` → `distribution: store` に変更（TestFlight 配信対応）
- `jest.config.js` に `.claude/` ディレクトリの除外パターンを追加（ワークツリーのテストが誤検知されていた問題を修正）

## 確認手順

1. GitHub リポジトリの Settings → Secrets に `EXPO_TOKEN` が設定済みであること
2. Actions タブから「EAS Build (iOS)」を手動実行し、ビルドが成功することを確認