### PR TITLE
chore: EAS Build を main マージ時に自動実行・production プロファイルに変更

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,6 +1,8 @@
 name: EAS Build (iOS)
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -22,5 +24,10 @@ jobs:
 
       - name: Build iOS (preview)
         run: eas build --platform ios --profile preview --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Submit to TestFlight
+        run: eas submit --platform ios --profile production --latest --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: EAS Build iOS Preview
+    name: EAS Build iOS Production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Install EAS CLI
         run: npm install -g eas-cli
 
-      - name: Build iOS (preview)
-        run: eas build --platform ios --profile preview --non-interactive
+      - name: Build iOS (production)
+        run: eas build --platform ios --profile production --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 


### PR DESCRIPTION
## 変更内容

#190 マージ後に追加した変更のフォローアップ PR。

- トリガーに `push: branches: [main]` を追加（main マージ時に自動実行）
- ビルドプロファイルを `preview` → `production` に変更（`autoIncrement` 有効）
- `eas submit` を追加（TestFlight へ自動アップロード）
- job 名を「EAS Build iOS Production」に修正

Closes #190