### PR TITLE
fix: スプラッシュ画面の背景色を白に変更

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "リトルベビーログ",
     "slug": "little-baby-log",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -10,11 +10,11 @@
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
-      "backgroundColor": "#D6EFE6"
+      "backgroundColor": "#FFFFFF"
     },
     "ios": {
       "bundleIdentifier": "studio.teeda.littlebabylog",
-      "buildNumber": "9",
+      "buildNumber": "10",
       "supportsTablet": false,
       "infoPlist": {
         "CFBundleDevelopmentRegion": "ja_JP",


### PR DESCRIPTION
## Summary
- スプラッシュ画面の背景色を `#D6EFE6`（薄いミント）から `#FFFFFF`（白）に変更
- `version`: 1.4.3 → 1.4.4（パッチ +1）
- `ios.buildNumber`: 9 → 10（+1）

## 変更ファイル
- `app.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)