### PR TITLE
chore: expo.install.excludeでExpo Doctorのパッチバージョンチェックを除外

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,5 +66,14 @@
     "typescript": "~5.9.2",
     "uuid": "^13.0.0"
   },
-  "private": true
+  "private": true,
+  "expo": {
+    "install": {
+      "exclude": [
+        "expo",
+        "expo-file-system",
+        "expo-font"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## 変更内容

`package.json` に `expo.install.exclude` を追加し、Expo Doctor のパッチバージョンチェックから以下のパッケージを除外する。

- `expo`
- `expo-file-system`
- `expo-font`

## 背景

これらのパッケージについて、Expo Doctor が期待するパッチバージョン（`54.0.35`、`19.0.23`、`14.0.12`）がまだ npm に公開されていないため、Expo Doctor が常に失敗する状態になっている。

`expo.install.exclude` はExpo公式のサポートする設定で、特定パッケージをバージョン互換チェックから除外できる。パッケージが実際にリリースされれば、この設定を外すか放置しても問題ない。

PR #203 の CI 修正で適用済み。mainにも反映する。