### PR TITLE
fix: 「このアプリについて」のバージョン表記を動的取得に変更

### DIFF
--- a/__tests__/app.navigation.ui.jest.test.tsx
+++ b/__tests__/app.navigation.ui.jest.test.tsx
@@ -1,62 +1,79 @@
-import React from 'react';
-import renderer, { act } from 'react-test-renderer';
+import React from "react";
+import renderer, { act } from "react-test-renderer";
 
 const mockRegisterRootComponent = jest.fn();
 const mockUseFonts = jest.fn();
-const mockLegalText = jest.fn(({ text }) => React.createElement('LegalTextScreen', { text }));
-const mockNavigationContainer = jest.fn(({ children, theme }) =>
-  React.createElement('NavigationContainer', { theme }, children)
+const mockLegalText = jest.fn(({ text }) =>
+  React.createElement("LegalTextScreen", { text })
 );
-const mockDateViewProvider = jest.fn(({ children }) => React.createElement('DateViewProvider', null, children));
-const mockRootNavigator = jest.fn(() => React.createElement('RootNavigator'));
-const mockAppStateProvider = jest.fn(({ children }) => React.createElement('AppStateProvider', null, children));
-const mockAchievementsProvider = jest.fn(({ children }) => React.createElement('AchievementsProvider', null, children));
+const mockNavigationContainer = jest.fn(({ children, theme }) =>
+  React.createElement("NavigationContainer", { theme }, children)
+);
+const mockDateViewProvider = jest.fn(({ children }) =>
+  React.createElement("DateViewProvider", null, children)
+);
+const mockRootNavigator = jest.fn(() => React.createElement("RootNavigator"));
+const mockAppStateProvider = jest.fn(({ children }) =>
+  React.createElement("AppStateProvider", null, children)
+);
+const mockAchievementsProvider = jest.fn(({ children }) =>
+  React.createElement("AchievementsProvider", null, children)
+);
 
-jest.mock('expo', () => ({
+jest.mock("expo", () => ({
   registerRootComponent: (...args: any[]) => mockRegisterRootComponent(...args),
 }));
 
-jest.mock('@expo-google-fonts/zen-maru-gothic', () => ({
+jest.mock("@expo-google-fonts/zen-maru-gothic", () => ({
   useFonts: (...args: any[]) => mockUseFonts(...args),
-  ZenMaruGothic_400Regular: 'font-400',
-  ZenMaruGothic_500Medium: 'font-500',
+  ZenMaruGothic_400Regular: "font-400",
+  ZenMaruGothic_500Medium: "font-500",
 }));
 
-jest.mock('@/screens/LegalTextScreen', () => ({
+jest.mock("@/screens/LegalTextScreen", () => ({
   __esModule: true,
   default: (props: any) => mockLegalText(props),
 }));
 
-jest.mock('@react-navigation/native', () => ({
+jest.mock("@react-navigation/native", () => ({
   NavigationContainer: (props: any) => mockNavigationContainer(props),
   DefaultTheme: {
-    colors: { background: 'bg-default', text: 'text-default', card: 'card-default' },
+    colors: {
+      background: "bg-default",
+      text: "text-default",
+      card: "card-default",
+    },
   },
 }));
 
-jest.mock('@/state/DateViewContext', () => ({
+jest.mock("@/state/DateViewContext", () => ({
   DateViewProvider: (props: any) => mockDateViewProvider(props),
 }));
 
-jest.mock('@/navigation/RootNavigator', () => ({
+jest.mock("@/navigation/RootNavigator", () => ({
   __esModule: true,
   default: () => mockRootNavigator(),
 }));
 
-jest.mock('@/state/AppStateContext', () => ({
+jest.mock("@/state/AppStateContext", () => ({
   AppStateProvider: (props: any) => mockAppStateProvider(props),
 }));
 
-jest.mock('@/state/AchievementsContext', () => ({
+jest.mock("@/state/AchievementsContext", () => ({
   AchievementsProvider: (props: any) => mockAchievementsProvider(props),
 }));
 
-describe('App / navigation / legal wrappers', () => {
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: { expoConfig: { version: "1.2.3" } },
+}));
+
+describe("App / navigation / legal wrappers", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  test('src/App.tsx: fonts未ロード時はnull', () => {
+  test("src/App.tsx: fonts未ロード時はnull", () => {
     mockUseFonts.mockReturnValue([false]);
-    const App = require('../src/App').default;
+    const App = require("../src/App").default;
     let tree: any;
     act(() => {
       tree = renderer.create(React.createElement(App)).toJSON();
@@ -64,9 +81,9 @@ describe('App / navigation / legal wrappers', () => {
     expect(tree).toBeNull();
   });
 
-  test('src/App.tsx: fontsロード後はProviderチェーンを描画', () => {
+  test("src/App.tsx: fontsロード後はProviderチェーンを描画", () => {
     mockUseFonts.mockReturnValue([true]);
-    const App = require('../src/App').default;
+    const App = require("../src/App").default;
     act(() => {
       renderer.create(React.createElement(App));
     });
@@ -75,30 +92,35 @@ describe('App / navigation / legal wrappers', () => {
     expect(mockNavigationContainer).toHaveBeenCalledTimes(1);
   });
 
-  test('index.ts: registerRootComponentを実行', () => {
+  test("index.ts: registerRootComponentを実行", () => {
     jest.isolateModules(() => {
-      require('../index');
+      require("../index");
     });
     expect(mockRegisterRootComponent).toHaveBeenCalledTimes(1);
   });
 
-  test('src/navigation/index.tsx: themeとProviderを適用', () => {
-    const Navigator = require('../src/navigation/index').default;
+  test("src/navigation/index.tsx: themeとProviderを適用", () => {
+    const Navigator = require("../src/navigation/index").default;
     act(() => {
       renderer.create(React.createElement(Navigator));
     });
     const passedTheme = mockNavigationContainer.mock.calls[0][0].theme;
-    expect(passedTheme.colors.background).toBe('#FFFDF7');
-    expect(passedTheme.colors.text).toBe('#4A3F35');
+    expect(passedTheme.colors.background).toBe("#FFFDF7");
+    expect(passedTheme.colors.text).toBe("#4A3F35");
     expect(mockDateViewProvider).toHaveBeenCalledTimes(1);
     expect(mockRootNavigator).toHaveBeenCalledTimes(1);
   });
 
-  test('About/Terms/PrivacyPolicy screens pass correct text props', () => {
-    const { ABOUT_TEXT_JA, TERMS_TEXT_JA, PRIVACY_POLICY_TEXT_JA } = require('../src/content/legal/ja');
-    const AboutScreen = require('../src/screens/AboutScreen').default;
-    const TermsScreen = require('../src/screens/TermsScreen').default;
-    const PrivacyPolicyScreen = require('../src/screens/PrivacyPolicyScreen').default;
+  test("About/Terms/PrivacyPolicy screens pass correct text props", () => {
+    const {
+      getAboutTextJa,
+      TERMS_TEXT_JA,
+      PRIVACY_POLICY_TEXT_JA,
+    } = require("../src/content/legal/ja");
+    const AboutScreen = require("../src/screens/AboutScreen").default;
+    const TermsScreen = require("../src/screens/TermsScreen").default;
+    const PrivacyPolicyScreen =
+      require("../src/screens/PrivacyPolicyScreen").default;
 
     act(() => {
       renderer.create(React.createElement(AboutScreen));
@@ -107,6 +129,12 @@ describe('App / navigation / legal wrappers', () => {
     });
 
     const passedTexts = mockLegalText.mock.calls.map(([props]) => props.text);
-    expect(passedTexts).toEqual(expect.arrayContaining([ABOUT_TEXT_JA, TERMS_TEXT_JA, PRIVACY_POLICY_TEXT_JA]));
+    expect(passedTexts).toEqual(
+      expect.arrayContaining([
+        getAboutTextJa("1.2.3"),
+        TERMS_TEXT_JA,
+        PRIVACY_POLICY_TEXT_JA,
+      ])
+    );
   });
 });

--- a/__tests__/models.types.content.jest.test.ts
+++ b/__tests__/models.types.content.jest.test.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_SETTINGS } from "../src/types/models";
 import {
-  ABOUT_TEXT_JA,
+  getAboutTextJa,
   LEGAL_META,
   PRIVACY_POLICY_TEXT_JA,
   TERMS_TEXT_JA,
@@ -26,13 +26,14 @@ describe("content/legal/ja exports", () => {
   it("LEGAL_METAに公開情報を含む", () => {
     expect(LEGAL_META.appName).toBe("リトルベビーログ");
     expect(LEGAL_META.contactEmail).toContain("@");
-    expect(LEGAL_META.initialVersionLabel).toMatch(/^Version\s\d+\.\d+\.\d+$/);
   });
 
   it("ABOUT文面に主要セクションを含む", () => {
-    expect(ABOUT_TEXT_JA).toContain("# このアプリについて");
-    expect(ABOUT_TEXT_JA).toContain("## 修正月齢・在胎週数の計算方法について");
-    expect(ABOUT_TEXT_JA).toContain(LEGAL_META.contactEmail);
+    const aboutText = getAboutTextJa("1.0.0");
+    expect(aboutText).toContain("# このアプリについて");
+    expect(aboutText).toContain("## 修正月齢・在胎週数の計算方法について");
+    expect(aboutText).toContain(LEGAL_META.contactEmail);
+    expect(aboutText).toContain("Version 1.0.0");
   });
 
   it("利用規約文面に施行日が含まれる", () => {

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "リトルベビーログ",
     "slug": "little-baby-log",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -14,7 +14,7 @@
     },
     "ios": {
       "bundleIdentifier": "studio.teeda.littlebabylog",
-      "buildNumber": "12",
+      "buildNumber": "13",
       "supportsTablet": false,
       "infoPlist": {
         "CFBundleDevelopmentRegion": "ja_JP",

--- a/src/content/legal/ja.ts
+++ b/src/content/legal/ja.ts
@@ -3,10 +3,9 @@ export const LEGAL_META = {
   operatorName: "Teeda Studio",
   contactEmail: "teeda.studio@gmail.com",
   effectiveDate: "2026年3月15日",
-  initialVersionLabel: "Version 1.0.0",
 } as const;
 
-export const ABOUT_TEXT_JA = `# このアプリについて
+export const getAboutTextJa = (version: string) => `# このアプリについて
 
 「リトルベビーログ」は、早産で生まれたお子さまの修正月齢を確認しながら、日々の成長や小さな出来事を記録できるアプリです。
 
@@ -74,7 +73,7 @@ teeda.studio@gmail.com
 
 ## バージョン
 
-Version 1.0.0
+Version ${version}
 `;
 
 export const TERMS_TEXT_JA = `# 利用規約

--- a/src/screens/AboutScreen.tsx
+++ b/src/screens/AboutScreen.tsx
@@ -1,15 +1,23 @@
 import React from "react";
 
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import Constants from "expo-constants";
 
-import { ABOUT_TEXT_JA } from "@/content/legal/ja";
+import { getAboutTextJa } from "@/content/legal/ja";
 import { SettingsStackParamList } from "@/navigation";
 import LegalTextScreen from "@/screens/LegalTextScreen";
 
 type Props = NativeStackScreenProps<SettingsStackParamList, "About">;
 
 const AboutScreen: React.FC<Props> = ({ navigation }) => {
-  return <LegalTextScreen text={ABOUT_TEXT_JA} title="このアプリについて" onBack={() => navigation.goBack()} />;
+  const version = Constants.expoConfig?.version ?? "unknown";
+  return (
+    <LegalTextScreen
+      text={getAboutTextJa(version)}
+      title="このアプリについて"
+      onBack={() => navigation.goBack()}
+    />
+  );
 };
 
 export default AboutScreen;


### PR DESCRIPTION
## 概要

「このアプリについて」画面のバージョン表記が `1.0.0` のままになっていたバグを修正。

## 変更内容

- `ABOUT_TEXT_JA`（定数）→ `getAboutTextJa(version: string)`（関数）に変更
- `AboutScreen.tsx` で `expo-constants` から `Constants.expoConfig?.version` を取得してバージョンを動的注入
- `LEGAL_META` の未使用フィールド `initialVersionLabel` を削除
- テスト（2ファイル）を新しい関数シグネチャに合わせて更新

## 効果

今後 `app.json` のバージョンを更新するだけで、「このアプリについて」画面のバージョン表記も自動的に最新になる。

## 確認手順

1. アプリを起動
2. 設定 → このアプリについて を開く
3. 末尾の「バージョン」セクションが `Version 1.5.2` と表示されること

## バージョン変更

- `version`: 1.5.1 → 1.5.2（バグ修正）
- `ios.buildNumber`: 12 → 13

Closes #205