### PR TITLE
fix: GoogleService-Info.plistのEASビルド配置を修正

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,10 @@
+const appJson = require("./app.json");
+
+module.exports = ({ config }) => ({
+  ...config,
+  ios: {
+    ...config.ios,
+    googleServicesFile:
+      process.env.GOOGLE_SERVICES_IOS ?? config.ios?.googleServicesFile,
+  },
+});

--- a/app.json
+++ b/app.json
@@ -13,6 +13,7 @@
       "backgroundColor": "#FFFFFF"
     },
     "ios": {
+      "googleServicesFile": "./GoogleService-Info.plist",
       "bundleIdentifier": "studio.teeda.littlebabylog",
       "buildNumber": "14",
       "supportsTablet": false,

--- a/eas.json
+++ b/eas.json
@@ -12,8 +12,7 @@
       "distribution": "store"
     },
     "production": {
-      "autoIncrement": true,
-      "prebuildCommand": "cp $GOOGLE_SERVICES_IOS ./GoogleService-Info.plist"
+      "autoIncrement": true
     }
   },
   "submit": {


### PR DESCRIPTION
## 変更内容

#213 のビルド失敗を修正。

## 問題

`eas.json` の `prebuildCommand` は `expo` のサブコマンドとして実行される仕様のため、`cp $GOOGLE_SERVICES_IOS ...` が `npx expo cp ... --platform ios` に変換されてビルドが失敗していた。

## 修正

- `app.config.js` を追加し、`process.env.GOOGLE_SERVICES_IOS`（EAS Secretsのファイルパス）を `ios.googleServicesFile` に直接渡すよう変更
- `eas.json` の `prebuildCommand` を削除

## 動作

- EASビルド時：`$GOOGLE_SERVICES_IOS`（EAS Secretsのファイルパス）を使用
- ローカル開発時：`app.json` の `./GoogleService-Info.plist` にフォールバック