### PR TITLE
fix: GoogleUtilitiesのmodular_headersを有効化してpod installエラーを解消

### DIFF
--- a/app.json
+++ b/app.json
@@ -39,6 +39,14 @@
     "plugins": [
       "@react-native-community/datetimepicker",
       "@react-native-firebase/app",
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "extraPodfileContent": "pod 'GoogleUtilities', :modular_headers => true"
+          }
+        }
+      ],
       "expo-font",
       "expo-image-picker",
       "expo-tracking-transparency",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@react-navigation/native-stack": "^7.8.0",
         "babel-preset-expo": "~54.0.10",
         "expo": "~54.0.34",
-        "expo-build-properties": "^56.0.18",
+        "expo-build-properties": "~1.0.10",
         "expo-dev-client": "~6.0.21",
         "expo-document-picker": "~14.0.8",
         "expo-file-system": "~19.0.22",
@@ -6820,24 +6820,17 @@
       }
     },
     "node_modules/expo-build-properties": {
-      "version": "56.0.18",
-      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-56.0.18.tgz",
-      "integrity": "sha512-at03ytur1Vfyl9ddtRMqIdSyR/oV57GM04+NZ5rhFTF0mC7dmKzxS9RBb34KHDPdT8UwUt7KsKbzYD1lnxLAKg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-1.0.10.tgz",
+      "integrity": "sha512-mFCZbrbrv0AP5RB151tAoRzwRJelqM7bCJzCkxpu+owOyH+p/rFC/q7H5q8B9EpVWj8etaIuszR+gKwohpmu1Q==",
       "license": "MIT",
       "dependencies": {
-        "@expo/schema-utils": "^56.0.0",
-        "resolve-from": "^5.0.0",
+        "ajv": "^8.11.0",
         "semver": "^7.6.0"
       },
       "peerDependencies": {
         "expo": "*"
       }
-    },
-    "node_modules/expo-build-properties/node_modules/@expo/schema-utils": {
-      "version": "56.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-56.0.1.tgz",
-      "integrity": "sha512-CZ/+mYbQmWeOnkCGlWy9K+lFxbJSMFY7+TqBZcKzBSTU5Q7IGRvn/sOG3TdNjIdLPmbA8xe7R/c3UUQ28R9i9w==",
-      "license": "MIT"
     },
     "node_modules/expo-build-properties/node_modules/semver": {
       "version": "7.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@react-navigation/native-stack": "^7.8.0",
         "babel-preset-expo": "~54.0.10",
         "expo": "~54.0.34",
+        "expo-build-properties": "^56.0.18",
         "expo-dev-client": "~6.0.21",
         "expo-document-picker": "~14.0.8",
         "expo-file-system": "~19.0.22",
@@ -6816,6 +6817,38 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-build-properties": {
+      "version": "56.0.18",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-56.0.18.tgz",
+      "integrity": "sha512-at03ytur1Vfyl9ddtRMqIdSyR/oV57GM04+NZ5rhFTF0mC7dmKzxS9RBb34KHDPdT8UwUt7KsKbzYD1lnxLAKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^56.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/@expo/schema-utils": {
+      "version": "56.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-56.0.1.tgz",
+      "integrity": "sha512-CZ/+mYbQmWeOnkCGlWy9K+lFxbJSMFY7+TqBZcKzBSTU5Q7IGRvn/sOG3TdNjIdLPmbA8xe7R/c3UUQ28R9i9w==",
+      "license": "MIT"
+    },
+    "node_modules/expo-build-properties/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@react-navigation/native-stack": "^7.8.0",
     "babel-preset-expo": "~54.0.10",
     "expo": "~54.0.34",
+    "expo-build-properties": "^56.0.18",
     "expo-dev-client": "~6.0.21",
     "expo-document-picker": "~14.0.8",
     "expo-file-system": "~19.0.22",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@react-navigation/native-stack": "^7.8.0",
     "babel-preset-expo": "~54.0.10",
     "expo": "~54.0.34",
-    "expo-build-properties": "^56.0.18",
+    "expo-build-properties": "~1.0.10",
     "expo-dev-client": "~6.0.21",
     "expo-document-picker": "~14.0.8",
     "expo-file-system": "~19.0.22",


### PR DESCRIPTION
## 変更内容

#215 のpod installエラーを修正。

## 問題

Firebase iOS SDK 12.x（`@react-native-firebase` v24で使用）がSwift製に移行したため、`FirebaseCoreInternal`が`GoogleUtilities`をimportする際にモジュールマップが必要になった。Static Libraryとして統合しようとするとエラーになる。

## 修正

`expo-build-properties` を追加し、Podfileに `pod 'GoogleUtilities', :modular_headers => true` を設定。

Closes #208