### PR TITLE
fix: Firebase Analytics iOS pod install エラーを修正

### DIFF
--- a/app.json
+++ b/app.json
@@ -43,7 +43,12 @@
         "expo-build-properties",
         {
           "ios": {
-            "extraPodfileContent": "pod 'GoogleUtilities', :modular_headers => true"
+            "extraPods": [
+              {
+                "name": "GoogleUtilities",
+                "modular_headers": true
+              }
+            ]
           }
         }
       ],

--- a/app.json
+++ b/app.json
@@ -43,12 +43,8 @@
         "expo-build-properties",
         {
           "ios": {
-            "extraPods": [
-              {
-                "name": "GoogleUtilities",
-                "modular_headers": true
-              }
-            ]
+            "useFrameworks": "static",
+            "forceStaticLinking": ["RNFBAnalytics", "RNFBApp"]
           }
         }
       ],


### PR DESCRIPTION
## 変更内容

EASビルドでのFirebase Analytics iOS pod installエラーを修正。

### 問題
`firebase-ios-sdk` 12.x（Swift製）は `use_frameworks!` が必須。これがないと `FirebaseCoreInternal depends upon GoogleUtilities, which does not define modules` エラーでpod installが失敗する。

### 解決策
公式ドキュメント（https://rnfirebase.io）の推奨設定に従い、`expo-build-properties`の設定を変更：

- `useFrameworks: "static"` → Podfileに `use_frameworks! :linkage => :static` を追加し、modular headers問題を根本解消
- `forceStaticLinking: ["RNFBAnalytics", "RNFBApp"]` → Expo 54 + RN 0.84+のprebuilt coreとの互換性確保

### 確認手順
EASビルドを実行してiOS pod installが成功することを確認。

Closes #208