### PR TITLE
chore: analytics.tsのFirebase importを遅延読み込みにする

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "リトルベビーログ",
     "slug": "little-baby-log",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -14,7 +14,7 @@
     },
     "ios": {
       "bundleIdentifier": "studio.teeda.littlebabylog",
-      "buildNumber": "15",
+      "buildNumber": "16",
       "supportsTablet": false,
       "infoPlist": {
         "CFBundleDevelopmentRegion": "ja_JP",

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,3 +1,5 @@
+import type analytics from "@react-native-firebase/analytics";
+
 const guard = async (fn: () => Promise<void>) => {
   if (__DEV__) return;
   try {
@@ -9,8 +11,9 @@ const guard = async (fn: () => Promise<void>) => {
 
 const logEvent = (name: string) =>
   guard(() => {
-    const analytics = require("@react-native-firebase/analytics").default;
-    return analytics().logEvent(name);
+    const getAnalytics: typeof analytics =
+      require("@react-native-firebase/analytics").default;
+    return getAnalytics().logEvent(name);
   });
 
 export const logRecordCreated = () => logEvent("record_created");

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,5 +1,3 @@
-import analytics from "@react-native-firebase/analytics";
-
 const guard = async (fn: () => Promise<void>) => {
   if (__DEV__) return;
   try {
@@ -9,14 +7,16 @@ const guard = async (fn: () => Promise<void>) => {
   }
 };
 
-export const logRecordCreated = () =>
-  guard(() => analytics().logEvent("record_created"));
+const logEvent = (name: string) =>
+  guard(() => {
+    const analytics = require("@react-native-firebase/analytics").default;
+    return analytics().logEvent(name);
+  });
 
-export const logCalendarOpened = () =>
-  guard(() => analytics().logEvent("calendar_opened"));
+export const logRecordCreated = () => logEvent("record_created");
 
-export const logTodayOpened = () =>
-  guard(() => analytics().logEvent("today_opened"));
+export const logCalendarOpened = () => logEvent("calendar_opened");
 
-export const logProfileCreated = () =>
-  guard(() => analytics().logEvent("profile_created"));
+export const logTodayOpened = () => logEvent("today_opened");
+
+export const logProfileCreated = () => logEvent("profile_created");


### PR DESCRIPTION
## 概要
`src/services/analytics.ts` の `@react-native-firebase/analytics` を静的importから、`src/components/AdBanner.tsx` と同様に `__DEV__` 判定後の `require()` による遅延読み込みに変更。

## 背景
静的importのままだと `__DEV__` で送信をスキップしていてもネイティブモジュール（RNFBAppModule）の読み込みが走ってしまい、Expo Goでの起動時にクラッシュしていた。

## 変更内容
- `analytics.ts`: 静的importを廃止し、共通ヘルパー `logEvent(name)` 内で本番実行時のみ `require()` する形に整理
- 本番でのAnalytics送信挙動（`__DEV__`では送らない）は変更なし
- `app.json`: version 1.7.1→1.7.2（バグ修正のためパッチ+1）、buildNumber 15→16

## 確認手順
- [x] `npm run typecheck` 通過
- [x] `npm run test:unit` 全224件通過
- [x] `/code-review` (high effort) 実施、CONFIRMED/PLAUSIBLEな指摘なし

Closes #225