### PR TITLE
fix: 写真ライブラリ保存/カメラ権限の説明文を修正しApp Store審査リジェクトに対応

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "リトルベビーログ",
     "slug": "little-baby-log",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -14,7 +14,7 @@
     },
     "ios": {
       "bundleIdentifier": "studio.teeda.littlebabylog",
-      "buildNumber": "18",
+      "buildNumber": "19",
       "supportsTablet": false,
       "infoPlist": {
         "CFBundleDevelopmentRegion": "ja_JP",
@@ -49,7 +49,21 @@
         }
       ],
       "expo-font",
-      "expo-image-picker",
+      [
+        "expo-image-picker",
+        {
+          "cameraPermission": false,
+          "microphonePermission": false
+        }
+      ],
+      [
+        "expo-media-library",
+        {
+          "savePhotosPermission": "「今日の記録」画面で作成した画像を写真アプリに保存するために使用します。",
+          "photosPermission": "成長記録に写真を添付するために使用します。",
+          "isAccessMediaLocationEnabled": false
+        }
+      ],
       "expo-tracking-transparency",
       [
         "react-native-google-mobile-ads",


### PR DESCRIPTION
## 概要
v1.7.4がApp Store審査で「placeholder or otherwise insufficient purpose strings」を理由にリジェクトされた。原因を調査し、以下2点を修正した。

- `TodayScreen` が `expo-media-library` の `saveToLibraryAsync` で「今日の記録」画像を写真ライブラリへ書き込むが、`NSPhotoLibraryAddUsageDescription` が未設定・プラグイン未登録だった（#229 で既に指摘されていた未対応課題）
- `expo-image-picker` プラグインが未使用のカメラ/マイク権限に対し、デフォルトの英語プレースホルダー文言（"Allow $(PRODUCT_NAME) to access your camera" 等）をバイナリに含めていた（アプリはライブラリ選択のみでカメラ・録音機能は未使用）

## 修正内容
- `app.json` の `plugins` に `expo-media-library` を追加し、保存用の権限説明文（日本語）を設定
- `expo-image-picker` プラグインで `cameraPermission: false` / `microphonePermission: false` を指定し、未使用の権限説明文を除去
- `version` を `1.7.4` → `1.7.5`、`ios.buildNumber` を `18` → `19` に更新

## 確認手順
1. EASビルドでiOS用ビルドを作成する
2. 「今日の記録」画面から画像保存を実行し、権限ダイアログの文言が日本語で表示され、保存が成功することを確認する
3. 成長記録への写真添付機能が引き続き正常に動作することを確認する
4. Info.plist（EASビルド成果物）に `NSCameraUsageDescription` / `NSMicrophoneUsageDescription` が含まれないことを確認する

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr4Yg38e1hi2mLBmSCj2HT