### PR TITLE
fix: ATT許諾ダイアログが表示されない審査リジェクトに対応

### DIFF
--- a/__tests__/AdBanner.ui.jest.test.tsx
+++ b/__tests__/AdBanner.ui.jest.test.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { render } from "@testing-library/react-native";
 
+import AdBanner from "@/components/AdBanner";
+import { TrackingReadyProvider } from "@/state/TrackingReadyContext";
+
 jest.mock("react-native-google-mobile-ads", () => ({
   BannerAd: () => null,
   BannerAdSize: { BANNER: "BANNER" },
@@ -12,22 +15,34 @@ describe("AdBanner", () => {
   afterEach(() => {
     // @ts-ignore
     global.__DEV__ = originalDev;
-    jest.resetModules();
   });
 
   test("__DEV__ === true のとき、プレースホルダーを表示する", () => {
     // @ts-ignore
     global.__DEV__ = true;
-    const AdBanner = require("../src/components/AdBanner").default;
     const { getByTestId } = render(<AdBanner />);
     expect(getByTestId("ad-banner-placeholder")).toBeTruthy();
   });
 
-  test("__DEV__ === false のとき、AdMob バナーをレンダリングする", () => {
+  test("ATT許諾フローが未完了のとき、何も表示しない", () => {
     // @ts-ignore
     global.__DEV__ = false;
-    const AdBanner = require("../src/components/AdBanner").default;
-    const { getByTestId } = render(<AdBanner />);
+    const { queryByTestId } = render(
+      <TrackingReadyProvider value={false}>
+        <AdBanner />
+      </TrackingReadyProvider>
+    );
+    expect(queryByTestId("ad-banner-real")).toBeNull();
+  });
+
+  test("ATT許諾フロー完了後、AdMob バナーをレンダリングする", () => {
+    // @ts-ignore
+    global.__DEV__ = false;
+    const { getByTestId } = render(
+      <TrackingReadyProvider value={true}>
+        <AdBanner />
+      </TrackingReadyProvider>
+    );
     expect(getByTestId("ad-banner-real")).toBeTruthy();
   });
 });

--- a/__tests__/app.navigation.ui.jest.test.tsx
+++ b/__tests__/app.navigation.ui.jest.test.tsx
@@ -74,7 +74,7 @@ describe("App / navigation / legal wrappers", () => {
   test("src/App.tsx: fonts未ロード時はnull", () => {
     mockUseFonts.mockReturnValue([false]);
     const App = require("../src/App").default;
-    let instance: renderer.ReactTestRenderer;
+    let instance: ReturnType<typeof renderer.create>;
     act(() => {
       instance = renderer.create(React.createElement(App));
     });
@@ -87,14 +87,14 @@ describe("App / navigation / legal wrappers", () => {
   test("src/App.tsx: fontsロード後はProviderチェーンを描画", async () => {
     mockUseFonts.mockReturnValue([true]);
     const App = require("../src/App").default;
-    let instance: renderer.ReactTestRenderer;
+    let instance: ReturnType<typeof renderer.create>;
     await act(async () => {
       instance = renderer.create(React.createElement(App));
     });
-    // useTrackingPermission がATT許諾フロー完了後に状態更新するため再レンダーが発生しうる
-    expect(mockAppStateProvider).toHaveBeenCalled();
-    expect(mockAchievementsProvider).toHaveBeenCalled();
-    expect(mockNavigationContainer).toHaveBeenCalled();
+    // isTrackingReady が false→true に変化するため初期描画+再描画の2回呼ばれる
+    expect(mockAppStateProvider).toHaveBeenCalledTimes(2);
+    expect(mockAchievementsProvider).toHaveBeenCalledTimes(2);
+    expect(mockNavigationContainer).toHaveBeenCalledTimes(2);
     act(() => {
       instance!.unmount();
     });

--- a/__tests__/app.navigation.ui.jest.test.tsx
+++ b/__tests__/app.navigation.ui.jest.test.tsx
@@ -74,22 +74,30 @@ describe("App / navigation / legal wrappers", () => {
   test("src/App.tsx: fonts未ロード時はnull", () => {
     mockUseFonts.mockReturnValue([false]);
     const App = require("../src/App").default;
-    let tree: any;
+    let instance: renderer.ReactTestRenderer;
     act(() => {
-      tree = renderer.create(React.createElement(App)).toJSON();
+      instance = renderer.create(React.createElement(App));
     });
-    expect(tree).toBeNull();
+    expect(instance!.toJSON()).toBeNull();
+    act(() => {
+      instance!.unmount();
+    });
   });
 
-  test("src/App.tsx: fontsロード後はProviderチェーンを描画", () => {
+  test("src/App.tsx: fontsロード後はProviderチェーンを描画", async () => {
     mockUseFonts.mockReturnValue([true]);
     const App = require("../src/App").default;
-    act(() => {
-      renderer.create(React.createElement(App));
+    let instance: renderer.ReactTestRenderer;
+    await act(async () => {
+      instance = renderer.create(React.createElement(App));
     });
-    expect(mockAppStateProvider).toHaveBeenCalledTimes(1);
-    expect(mockAchievementsProvider).toHaveBeenCalledTimes(1);
-    expect(mockNavigationContainer).toHaveBeenCalledTimes(1);
+    // useTrackingPermission がATT許諾フロー完了後に状態更新するため再レンダーが発生しうる
+    expect(mockAppStateProvider).toHaveBeenCalled();
+    expect(mockAchievementsProvider).toHaveBeenCalled();
+    expect(mockNavigationContainer).toHaveBeenCalled();
+    act(() => {
+      instance!.unmount();
+    });
   });
 
   test("index.ts: registerRootComponentを実行", () => {

--- a/__tests__/useTrackingPermission.jest.test.ts
+++ b/__tests__/useTrackingPermission.jest.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react-native";
+import { AppState } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Tracking from "expo-tracking-transparency";
 import { useTrackingPermission } from "../src/hooks/useTrackingPermission";
@@ -21,12 +22,14 @@ jest.mock("expo-tracking-transparency", () => ({
 const mockGetItem = AsyncStorage.getItem as jest.Mock;
 const mockSetItem = AsyncStorage.setItem as jest.Mock;
 const mockGetTracking = Tracking.getTrackingPermissionsAsync as jest.Mock;
-const mockRequestTracking = Tracking.requestTrackingPermissionsAsync as jest.Mock;
+const mockRequestTracking =
+  Tracking.requestTrackingPermissionsAsync as jest.Mock;
 
 describe("useTrackingPermission", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSetItem.mockResolvedValue(undefined);
+    AppState.currentState = "active";
   });
 
   test("ATTステータスが未決定のとき、requestTrackingPermissionsAsync を呼ぶ", async () => {
@@ -76,5 +79,31 @@ describe("useTrackingPermission", () => {
     });
     expect(mockGetTracking).not.toHaveBeenCalled();
     expect(mockRequestTracking).not.toHaveBeenCalled();
+  });
+
+  test("アプリがアクティブでないとき、activeになるまでリクエストを待つ", async () => {
+    // @ts-ignore
+    AppState.currentState = "background";
+    let changeHandler: ((state: string) => void) | undefined;
+    (AppState.addEventListener as jest.Mock).mockImplementation(
+      (_event, handler) => {
+        changeHandler = handler;
+        return { remove: jest.fn() };
+      }
+    );
+
+    mockGetItem.mockResolvedValue(null);
+    mockGetTracking.mockResolvedValue({ status: "undetermined" });
+    mockRequestTracking.mockResolvedValue({ status: "granted" });
+
+    renderHook(() => useTrackingPermission());
+
+    expect(mockGetTracking).not.toHaveBeenCalled();
+
+    changeHandler?.("active");
+
+    await waitFor(() => {
+      expect(mockRequestTracking).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "リトルベビーログ",
     "slug": "little-baby-log",
-    "version": "1.7.5",
+    "version": "1.7.6",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -14,7 +14,7 @@
     },
     "ios": {
       "bundleIdentifier": "studio.teeda.littlebabylog",
-      "buildNumber": "19",
+      "buildNumber": "20",
       "supportsTablet": false,
       "infoPlist": {
         "CFBundleDevelopmentRegion": "ja_JP",

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,10 @@
 jest.mock("expo-tracking-transparency", () => ({
-  getTrackingPermissionsAsync: jest.fn().mockResolvedValue({ status: "undetermined" }),
-  requestTrackingPermissionsAsync: jest.fn().mockResolvedValue({ status: "granted" }),
+  getTrackingPermissionsAsync: jest
+    .fn()
+    .mockResolvedValue({ status: "undetermined" }),
+  requestTrackingPermissionsAsync: jest
+    .fn()
+    .mockResolvedValue({ status: "granted" }),
   PermissionStatus: {
     UNDETERMINED: "undetermined",
     GRANTED: "granted",
@@ -11,4 +15,13 @@ jest.mock("expo-tracking-transparency", () => ({
 jest.mock("react-native-google-mobile-ads", () => ({
   BannerAd: () => null,
   BannerAdSize: { BANNER: "BANNER" },
+}));
+
+jest.mock("react-native/Libraries/AppState/AppState", () => ({
+  __esModule: true,
+  default: {
+    currentState: "active",
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+    removeEventListener: jest.fn(),
+  },
 }));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 import { StatusBar, View } from "react-native";
 
-import { useFonts, ZenMaruGothic_400Regular, ZenMaruGothic_500Medium } from "@expo-google-fonts/zen-maru-gothic";
+import {
+  useFonts,
+  ZenMaruGothic_400Regular,
+  ZenMaruGothic_500Medium,
+} from "@expo-google-fonts/zen-maru-gothic";
 
 import Navigator from "@/navigation";
 import { AppStateProvider } from "@/state/AppStateContext";
 import { AchievementsProvider } from "@/state/AchievementsContext";
+import { TrackingReadyProvider } from "@/state/TrackingReadyContext";
 import { useTrackingPermission } from "@/hooks/useTrackingPermission";
 
 const App: React.FC = () => {
-  useTrackingPermission();
+  const isTrackingReady = useTrackingPermission();
   const [fontsLoaded] = useFonts({
     "ZenMaruGothic-Regular": ZenMaruGothic_400Regular,
     "ZenMaruGothic-Medium": ZenMaruGothic_500Medium,
@@ -22,7 +27,9 @@ const App: React.FC = () => {
       <StatusBar barStyle="dark-content" />
       <AppStateProvider>
         <AchievementsProvider>
-          <Navigator />
+          <TrackingReadyProvider value={isTrackingReady}>
+            <Navigator />
+          </TrackingReadyProvider>
         </AchievementsProvider>
       </AppStateProvider>
     </View>

--- a/src/components/AdBanner.tsx
+++ b/src/components/AdBanner.tsx
@@ -1,16 +1,25 @@
 import React from "react";
 import { View, Text, StyleSheet } from "react-native";
 
+import { useTrackingReady } from "@/state/TrackingReadyContext";
+
 const BANNER_AD_UNIT_ID = "ca-app-pub-8166243489339783/3517337126";
 const BANNER_HEIGHT = 50;
 
 const AdBanner: React.FC = () => {
+  const isTrackingReady = useTrackingReady();
+
   if (__DEV__) {
     return (
       <View style={styles.placeholder} testID="ad-banner-placeholder">
         <Text style={styles.placeholderText}>Ad Banner</Text>
       </View>
     );
+  }
+
+  // ATT許諾フローが完了するまでAdMob SDKを初期化・広告リクエストさせない
+  if (!isTrackingReady) {
+    return null;
   }
 
   const { BannerAd, BannerAdSize } = require("react-native-google-mobile-ads");

--- a/src/hooks/useTrackingPermission.ts
+++ b/src/hooks/useTrackingPermission.ts
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
+import { AppState } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import {
   getTrackingPermissionsAsync,
@@ -10,10 +11,17 @@ import {
 const ATT_REQUESTED_KEY = "att_requested";
 
 export function useTrackingPermission() {
+  const [isResolved, setIsResolved] = useState(false);
+
   useEffect(() => {
+    let cancelled = false;
+
     async function requestIfNeeded() {
       const already = await AsyncStorage.getItem(ATT_REQUESTED_KEY);
-      if (already) return;
+      if (already) {
+        if (!cancelled) setIsResolved(true);
+        return;
+      }
 
       const { status } = await getTrackingPermissionsAsync();
       if (status === PermissionStatus.UNDETERMINED) {
@@ -21,8 +29,31 @@ export function useTrackingPermission() {
       }
 
       await AsyncStorage.setItem(ATT_REQUESTED_KEY, "true");
+      if (!cancelled) setIsResolved(true);
     }
 
-    requestIfNeeded();
+    // ウィンドウがアクティブになる前にATTダイアログを呼ぶと、
+    // iOS側がダイアログを表示せず解決してしまうことがあるため、
+    // アプリが完全にフォアグラウンド・アクティブになってからリクエストする
+    if (AppState.currentState === "active") {
+      requestIfNeeded();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const subscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState === "active") {
+        subscription.remove();
+        requestIfNeeded();
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      subscription.remove();
+    };
   }, []);
+
+  return isResolved;
 }

--- a/src/state/TrackingReadyContext.tsx
+++ b/src/state/TrackingReadyContext.tsx
@@ -1,0 +1,14 @@
+import React, { createContext, useContext } from "react";
+
+const TrackingReadyContext = createContext(false);
+
+export const TrackingReadyProvider: React.FC<{
+  value: boolean;
+  children: React.ReactNode;
+}> = ({ value, children }) => (
+  <TrackingReadyContext.Provider value={value}>
+    {children}
+  </TrackingReadyContext.Provider>
+);
+
+export const useTrackingReady = (): boolean => useContext(TrackingReadyContext);


### PR DESCRIPTION
## 背景
App Store Connect審査でGuideline 2.1 (Information Needed) によりリジェクト。
iPadOS 26.6の審査環境でATT（AppTrackingTransparency）許諾ダイアログが表示されなかった。

対象バージョン: 1.7.5 (29) / Submission ID: cf15483e-fc28-4804-8ca1-deb18626c550

## 原因
- `useTrackingPermission`がアプリ起動直後（`App`コンポーネントの最初のコミット、`fontsLoaded`判定より前）に即座にATT許諾リクエストを呼んでいた
- iOSはウィンドウが完全にアクティブになる前に許諾リクエストを呼ぶと、ダイアログを表示せず解決してしまうことがある（既知の挙動）
- 加えて、ATT許諾フローの完了を待たずに`AdBanner`（AdMob広告）が起動と同時にマウントされ、広告SDKの初期化・広告リクエストが並走していた

## 修正内容
- `src/hooks/useTrackingPermission.ts`: `AppState`が`active`になってからATT許諾リクエストを呼ぶように変更。フロー完了状態を返り値として公開
- `src/state/TrackingReadyContext.tsx`（新規）: ATT許諾フロー完了状態を配信するContext
- `src/App.tsx`: `TrackingReadyProvider`でNavigator配下をラップ
- `src/components/AdBanner.tsx`: ATT許諾フロー完了まで広告(BannerAd)をマウントしない
- `app.json`: version 1.7.5→1.7.6（バグ修正）、ios.buildNumber 19→20

## テスト
- `npm run typecheck` パス
- `npm test`（226件）パス
- `/code-review`実施・指摘（テストファイルの型エラー、アサーション緩和）を修正済み

## 確認手順
1. EAS Buildでビルド
2. フレッシュインストール（または設定→一般→VPNとデバイス管理→本アプリの位置情報等から許諾リセット）してアプリを起動
3. 起動後、ATT許諾ダイアログが確実に表示されることを確認
4. 許可/拒否いずれの場合も広告バナーがクラッシュなく表示されることを確認

Closes なし（対応するIssueは作成せず直接対応）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V1xni1souTrSW52rvTy66L